### PR TITLE
Add mix1 project detail pages with Bilbao-pattern layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { HomePage as Mix1HomePage } from './mix1/pages/HomePage';
 import { WorkPage as Mix1WorkPage } from './mix1/pages/WorkPage';
 import { AboutPage as Mix1AboutPage } from './mix1/pages/AboutPage';
 import { BuildPage as Mix1BuildPage } from './mix1/pages/BuildPage';
+import { ProjectPage as Mix1ProjectPage } from './mix1/pages/ProjectPage';
 import { POISED_BASE } from './content/site';
 import { MediaBlocksProvider } from './media-blocks/MediaBlocks';
 import { WireframeProvider } from './wireframe/Wireframe';
@@ -79,6 +80,7 @@ function AppRoutes() {
         <Route path="mix1" element={<Mix1Shell />}>
           <Route index element={<Mix1HomePage />} />
           <Route path="work" element={<Mix1WorkPage />} />
+          <Route path="work/:slug" element={<Mix1ProjectPage />} />
           <Route path="about" element={<Mix1AboutPage />} />
           <Route path="build" element={<Mix1BuildPage />} />
         </Route>

--- a/src/mix1/FigureStripes.tsx
+++ b/src/mix1/FigureStripes.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useState, type CSSProperties, type PointerEvent } from 'react';
+import { usePrefersReducedMotion } from './usePrefersReducedMotion';
+import { Picture } from '../studio/Picture';
+
+const FRAGMENTS = 7;
+const HALF = Math.floor(FRAGMENTS / 2);
+
+export function FigureStripes({
+  src,
+  alt = '',
+  className = '',
+}: {
+  src: string;
+  alt?: string;
+  className?: string;
+}) {
+  const reduced = usePrefersReducedMotion();
+  const [armed, setArmed] = useState(false);
+
+  const onPointerEnter = useCallback(() => {
+    if (!reduced) setArmed(true);
+  }, [reduced]);
+
+  const onPointerMove = useCallback((event: PointerEvent<HTMLElement>) => {
+    if (reduced) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width - 0.5) * 100;
+    event.currentTarget.style.setProperty('--mouse-x', String(x));
+  }, [reduced]);
+
+  const onPointerLeave = useCallback((event: PointerEvent<HTMLElement>) => {
+    event.currentTarget.style.setProperty('--mouse-x', '0');
+  }, []);
+
+  return (
+    <figure
+      className={`figure-stripes figure-stripes--intersected${armed ? ' figure-stripes--base-loaded' : ''} ${className}`.trim()}
+      style={
+        {
+          '--fragments': FRAGMENTS,
+          '--mouse-x': 0,
+          '--delay': 700,
+        } as CSSProperties
+      }
+      onPointerEnter={onPointerEnter}
+      onPointerMove={onPointerMove}
+      onPointerLeave={onPointerLeave}
+    >
+      <div className="figure-stripes__base">
+        <Picture src={src} alt={alt} className="picture--cover" />
+      </div>
+      {armed
+        ? Array.from({ length: FRAGMENTS }, (_, index) => (
+            <div
+              key={index}
+              className="figure-stripes__fragment"
+              style={
+                {
+                  '--f-index': index,
+                  '--multiplier': Math.abs(index - HALF),
+                  '--half': HALF,
+                } as CSSProperties
+              }
+            >
+              <Picture src={src} alt="" className="picture--cover" />
+            </div>
+          ))
+        : null}
+    </figure>
+  );
+}

--- a/src/mix1/Mix1Shell.tsx
+++ b/src/mix1/Mix1Shell.tsx
@@ -11,6 +11,7 @@ import './styles/mix1.css';
 function mix1Page(pathname: string) {
   if (pathname.includes('/build')) return 'build';
   if (pathname.includes('/about')) return 'about';
+  if (/\/mix1\/work\/.+/.test(pathname)) return 'work-detail';
   if (pathname.includes('/work')) return 'work';
   return 'home';
 }
@@ -71,7 +72,7 @@ export function Mix1Shell() {
     document.title =
       page === 'about'
         ? 'About — Osandi Robinson'
-        : page === 'work'
+        : page === 'work' || page === 'work-detail'
           ? 'Experiences — Osandi Robinson'
           : page === 'build'
             ? 'Build — Osandi Robinson'

--- a/src/mix1/content.ts
+++ b/src/mix1/content.ts
@@ -351,3 +351,395 @@ export const mix1Build = {
     href: '/mix1/work',
   },
 } as const;
+
+export const mix1Projects = [
+  {
+    slug: 'mezo-clay',
+    name: 'Mezo Clay Design System',
+    client: 'Mezo / Thesis',
+    sector: 'Crypto',
+    year: '2023',
+    service: 'Systems',
+    readTime: 4,
+    image: '/images/portfolio/mock-thesis-systems.png',
+    headline: 'Converting design debt into product infrastructure',
+    intro:
+      'What starts as a styling override always becomes a system problem. At Mezo, three product phases — legacy, testnet, mainnet — had accumulated enough inconsistency to slow every team touching the product. The work was infrastructure first, interface second.',
+    featuredSections: [
+      {
+        lead: 'A design system is only as good as the governance behind it.',
+        richTitle: 'Building the single source of truth',
+        body: [
+          "Led the full migration to Mezo Clay — partnering with Uber Base as the foundation and building a WCAG 2.2-compliant React library purpose-built for the Thesis BitcoinFi suite. Managed a direct report and an engineering contributor from execution through deployment.",
+          "The post-launch audit identified premature styling as the primary implementation bottleneck — a pattern that shows up in every fast-moving crypto team. The fix wasn't more components; it was clearer rules about when to override them.",
+        ],
+        images: ['/images/portfolio/mock-thesis-systems.png', '/images/portfolio/mezo-hero.png'],
+      },
+      {
+        lead: '2,000+ variants. 50+ base components. One source of truth.',
+        richTitle: 'Scale, compliance, and delivery',
+        body: [
+          "Partnered with the contributing designer to set quality standards and pattern library conventions. Built and tested every variant against the Mezo product surfaces — deposit, borrow, wallet, explore — so each could ship without a separate design review cycle.",
+          "The system became the infrastructure behind $322M in testnet deposits, 154K transactions, and $151M TVL at mainnet, peaking at $200M+.",
+        ],
+        images: ['/images/portfolio/mezo-wallet.png', '/images/portfolio/mezo-explore.png', '/images/portfolio/mezo-borrow.png'],
+      },
+      {
+        lead: 'Design debt compounds silently until it stops shipping features.',
+        richTitle: 'What the audit revealed',
+        body: [
+          "A 70% component integration rate at post-launch audit sounds like success. It is — but the 30% that wasn't integrated told the real story: premature styling decisions made during testnet were being maintained as one-off overrides instead of being resolved back into the system.",
+          "The governance decisions informed by that audit — when to override, when to extend, when to propose a new component — were as important as the components themselves.",
+        ],
+        images: ['/images/portfolio/mock-thesis-systems.png', '/images/portfolio/mezo-borrow.png'],
+      },
+    ],
+    mockups: [
+      '/images/portfolio/mock-thesis-systems.png',
+      '/images/portfolio/mezo-hero.png',
+      '/images/portfolio/mezo-wallet.png',
+    ],
+    closingLead: 'Infrastructure that outlasts the sprint cycle is the difference between a design system and a component dump.',
+    stats: [
+      { name: 'Component integration', description: 'Post-launch audit established the baseline for system governance decisions.', value: '70%' },
+      { name: 'TVL at mainnet peak', description: 'The system shipped with every product surface that contributed to Mezo growth.', value: '$200M+' },
+      { name: 'Testnet deposits', description: 'Built on the infrastructure shipped during this engagement.', value: '$322M' },
+      { name: 'Sprint completion', description: 'Maintained across the engagement from system build through deployment.', value: '98%' },
+    ],
+    tech: [
+      { k: 'Foundation', v: 'Uber Base → Mezo Clay' },
+      { k: 'Implementation', v: 'React + WCAG 2.2' },
+      { k: 'Scale', v: '2,000+ variants · 50+ components' },
+    ],
+    tags: ['Design systems', 'Lead', 'Crypto', 'WCAG 2.2', 'React', 'Component library'],
+    credits: [
+      { role: 'Design lead', name: 'Osandi Robinson' },
+      { role: 'Contributing designer', name: 'Poised LLC' },
+      { role: 'Engineering', name: 'Thesis engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'Mezo / Thesis' },
+      { role: 'PM', name: 'Thesis product team' },
+    ],
+  },
+  {
+    slug: 'deposit-on-mezo',
+    name: 'Deposit on Mezo',
+    client: 'Mezo / Thesis',
+    sector: 'Crypto',
+    year: '2023',
+    service: 'Product',
+    readTime: 3,
+    image: '/images/portfolio/project-hero-coinbase.png',
+    headline: "Improving the deposit flow that unlocked Mezo's liquidity",
+    intro:
+      "Depositing Bitcoin to Mezo wasn't a standard transfer. Users were bridging assets across chains into a protocol where a wrong address meant permanent loss of funds. The bar for clarity wasn't high — it was non-negotiable.",
+    featuredSections: [
+      {
+        lead: 'Research confirmed the flow was broken before we touched a pixel.',
+        richTitle: 'Diagnosing the problem',
+        body: [
+          "The existing deposit flow was perceived as risky and confusing — no upfront context, no network guidance, no unambiguous success state. Users had to infer what was happening at every step.",
+          "The redesign introduced upfront deposit instructions before any commitment, surfaced network context and minimum thresholds early, and delivered success states specific enough that users knew their funds had arrived safely — not just that a transaction had fired.",
+        ],
+        images: ['/images/portfolio/project-hero-coinbase.png', '/images/portfolio/project-after-coinbase.png'],
+      },
+      {
+        lead: 'The deposit flow became the primary on-ramp for all of Mezo\'s liquidity.',
+        richTitle: 'Outcome and downstream impact',
+        body: [
+          "Vaults, pools, and rewards all depended on a working deposit experience. The redesign unblocked each of them — contributing directly to Mezo's growth to $200M+ TVL.",
+          "Sprint completion held at 98% across the engagement, which meant the research and design process ran fast enough to stay ahead of engineering.",
+        ],
+        images: ['/images/portfolio/mezo-hero.png', '/images/portfolio/mezo-explore.png'],
+      },
+    ],
+    mockups: ['/images/portfolio/project-hero-coinbase.png', '/images/portfolio/project-after-coinbase.png', '/images/portfolio/mezo-hero.png'],
+    closingLead: 'Clarity at the point of commitment is not a UX nicety in a protocol where a wrong address means permanent loss.',
+    stats: [
+      { name: 'TVL at mainnet', description: 'Deposit flow was the primary on-ramp for all Mezo liquidity growth.', value: '$200M+' },
+      { name: 'Active users', description: 'Reached at mainnet launch, enabled by a deposit experience that worked.', value: '25K+' },
+      { name: 'Sprint completion', description: 'Maintained across the engagement from research through handoff.', value: '98%' },
+    ],
+    tech: [
+      { k: 'Platform', v: 'Mobile + Web' },
+      { k: 'Method', v: 'Research-led redesign' },
+      { k: 'Protocol', v: 'Bitcoin bridge · cross-chain' },
+    ],
+    tags: ['Product design', 'Crypto', 'Fintech', 'Research', 'Mobile', 'Web'],
+    credits: [
+      { role: 'Product design', name: 'Osandi Robinson' },
+      { role: 'Engineering', name: 'Thesis engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'Mezo / Thesis' },
+      { role: 'PM', name: 'Thesis product team' },
+    ],
+  },
+  {
+    slug: 'borrow-musd',
+    name: 'Borrow MUSD on Mezo',
+    client: 'Mezo / Thesis',
+    sector: 'Crypto',
+    year: '2023',
+    service: 'Product',
+    readTime: 3,
+    image: '/images/portfolio/project-01-borrow.png',
+    headline: 'Making high-stakes borrowing feel safe, not complex',
+    intro:
+      'MUSD borrowing required users to hold collateralization ratio, liquidation threshold, and variable APR in their heads simultaneously. None of those concepts have mainstream equivalents. The design problem was weight, not simplification.',
+    featuredSections: [
+      {
+        lead: 'Consequential decisions need to feel consequential — not overwhelming.',
+        richTitle: 'Progressive disclosure as the primary tool',
+        body: [
+          "Progressive disclosure let us surface complexity only when it was relevant to the decision at hand. A user setting their collateral ratio doesn't need to see APR mechanics at the same moment.",
+          "Error handling was consolidated to a single inline signal. Before the redesign, errors appeared in multiple places with inconsistent framing — adding cognitive load at the worst possible moment.",
+        ],
+        images: ['/images/portfolio/project-01-borrow.png', '/images/portfolio/project-02-loan.png'],
+      },
+      {
+        lead: 'Benchmarking against established DeFi patterns reduced the learning curve.',
+        richTitle: 'Expanding the addressable market',
+        body: [
+          "The redesign borrowed interaction models from familiar financial interfaces — not to hide the complexity of DeFi, but to lower the entry cost for users coming from traditional finance.",
+          "The borrow flow shipped as part of the mainnet launch suite, contributing to Mezo's $200M+ TVL and supporting expansion into a broader addressable market beyond early adopters.",
+        ],
+        images: ['/images/portfolio/project-03-wallet.png', '/images/portfolio/project-04-marketplace.png'],
+      },
+    ],
+    mockups: ['/images/portfolio/project-01-borrow.png', '/images/portfolio/project-02-loan.png', '/images/portfolio/project-03-wallet.png'],
+    closingLead: 'The job isn\'t to make DeFi simple. It\'s to make consequential decisions feel proportionally weighted.',
+    stats: [
+      { name: 'TVL at mainnet', description: 'Borrow flow contributed to Mezo\'s liquidity growth alongside deposit and wallet.', value: '$200M+' },
+      { name: 'Active users', description: 'Reached at mainnet launch across all Mezo product surfaces.', value: '25K+' },
+    ],
+    tech: [
+      { k: 'Platform', v: 'Mobile + Web' },
+      { k: 'Method', v: 'Progressive disclosure · benchmarking' },
+      { k: 'Protocol', v: 'MUSD collateralized borrowing' },
+    ],
+    tags: ['Product design', 'Crypto', 'DeFi', 'Research', 'Progressive disclosure'],
+    credits: [
+      { role: 'Product design', name: 'Osandi Robinson' },
+      { role: 'Engineering', name: 'Thesis engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'Mezo / Thesis' },
+      { role: 'PM', name: 'Thesis product team' },
+    ],
+  },
+  {
+    slug: 'blockfi-mobile',
+    name: 'BlockFi Mobile',
+    client: 'BlockFi',
+    sector: 'Fintech',
+    year: '2021',
+    service: 'Leadership',
+    readTime: 4,
+    image: '/images/portfolio/gf-blockfi.jpg',
+    headline: 'Redefining mobile trading to drive 200%+ transaction volume in 90 days',
+    intro:
+      "BlockFi's mobile trading had a surface problem and a structural one. USD denomination was the thing people complained about. The real issue was a flow built around what engineering found easiest to implement, not how traders actually think.",
+    featuredSections: [
+      {
+        lead: 'Pushing back on the brief was the first design decision.',
+        richTitle: 'Reframing the problem',
+        body: [
+          "Product benchmarking and heuristic evaluation surfaced a pattern no one had named yet: the segmented control forcing users to choose denomination before intent was the single biggest source of drop-off. Moving buy/sell intent before the amount screen eliminated it.",
+          "Recurring trades had been buried at the summary screen — three steps too late. Surfacing them earlier required a structural change to the flow that the original brief hadn't scoped. Both decisions were validated through user testing before implementation.",
+        ],
+        images: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/mock-bbu.png'],
+      },
+      {
+        lead: 'Trades grew 200%+ in 90 days. Mobile outpaced web for the first time.',
+        richTitle: 'Measuring the impact',
+        body: [
+          "The same changes were applied consistently across web and mobile — not as a one-off mobile fix but as a rethought trading interaction model. The consistency mattered as much as the individual improvements.",
+          "The result contributed directly to BlockFi's growth in service of 225K+ clients and $50M monthly revenue — and validated the case for design having a seat at product strategy decisions, not just execution.",
+        ],
+        images: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/gf-fennel.png'],
+      },
+    ],
+    mockups: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/mock-bbu.png', '/images/portfolio/gf-fennel.png'],
+    closingLead: 'The brief was too small. Pushing back on it was the design work.',
+    stats: [
+      { name: 'Trades in 90 days', description: 'Mobile outpaced web-based trades for the first time following launch.', value: '+200%' },
+      { name: 'Monthly revenue', description: 'BlockFi revenue at time of engagement, grown in part through trading volume.', value: '$50M' },
+      { name: 'Clients served', description: 'Active BlockFi users at time of mobile trading redesign launch.', value: '225K+' },
+    ],
+    tech: [
+      { k: 'Platform', v: 'iOS + Android + Web' },
+      { k: 'Method', v: 'Benchmarking · user testing' },
+      { k: 'Role', v: 'Director of Product Design' },
+    ],
+    tags: ['Lead', 'Fintech', 'Mobile', 'iOS', 'Android', 'Director'],
+    credits: [
+      { role: 'Design director', name: 'Osandi Robinson' },
+      { role: 'Product designers', name: 'BlockFi design team' },
+      { role: 'Engineering', name: 'BlockFi engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'BlockFi' },
+      { role: 'PM', name: 'BlockFi product team' },
+    ],
+  },
+  {
+    slug: 'cash-native-app',
+    name: 'C@SH Native App',
+    client: 'a16z Crypto portfolio',
+    sector: 'Crypto',
+    year: '2022',
+    service: 'Leadership',
+    readTime: 3,
+    image: '/images/portfolio/gf-cash.png',
+    headline: 'Zero-to-one product design that informed a strategic pivot',
+    intro:
+      "Building a design function before the first hire means every decision compounds. The component library you build becomes the product. The research you run becomes the strategy.",
+    featuredSections: [
+      {
+        lead: 'A branded component library before a single internal designer was hired.',
+        richTitle: 'Building the function from zero',
+        body: [
+          "Customized Uber Base into a branded library that doubled engineering speed and gave the team a shared vocabulary to build with from day one. The VC principal set a high bar — a premium product resonating with an urban audience — and we met it, validated through affinity testing.",
+          "Full light and dark mode shipped. The same research surfaced a harder finding: the market hadn't matured enough for a social wallet.",
+        ],
+        images: ['/images/portfolio/gf-cash.png', '/images/portfolio/mock-vinyl-crate.png'],
+      },
+      {
+        lead: "The research that shaped the pivot preserved capital that would otherwise have been spent.",
+        richTitle: 'When research becomes strategy',
+        body: [
+          "Identifying insufficient market traction before over-investing in the product direction was the most valuable output of the engagement. The design foundation remained intact for the company's next direction.",
+          "Building 0→1 means the research has to do double duty — validating the product and validating the strategy. Here, it did both.",
+        ],
+        images: ['/images/portfolio/mock-a16z.png', '/images/portfolio/gf-cash.png'],
+      },
+    ],
+    mockups: ['/images/portfolio/gf-cash.png', '/images/portfolio/mock-a16z.png', '/images/portfolio/mock-vinyl-crate.png'],
+    closingLead: 'The most valuable deliverable was the research that stopped us from building the wrong thing.',
+    stats: [
+      { name: 'Design function', description: 'Built from zero before the first internal design hire.', value: '0 → 1' },
+      { name: 'Engineering speed', description: 'Doubled by shipping a branded component library on day one.', value: '2×' },
+    ],
+    tech: [
+      { k: 'Foundation', v: 'Uber Base → custom library' },
+      { k: 'Platform', v: 'iOS + Android' },
+      { k: 'Method', v: 'Affinity testing · 0→1 build' },
+    ],
+    tags: ['0→1', 'Lead', 'Crypto', 'Mobile', 'iOS', 'Android', 'Design systems'],
+    credits: [
+      { role: 'Design lead', name: 'Osandi Robinson' },
+      { role: 'Engineering', name: 'C@SH engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'a16z Crypto portfolio' },
+      { role: 'PM', name: 'C@SH product team' },
+    ],
+  },
+  {
+    slug: 'easi-food-delivery',
+    name: 'EASI Food Delivery',
+    client: 'EASI',
+    sector: 'Consumer',
+    year: '2020',
+    service: 'Consultant',
+    readTime: 4,
+    image: '/images/portfolio/gf-easi.jpg',
+    headline: 'Rearchitecting EASI to win a second audience — and a $500M valuation',
+    intro:
+      "EASI had a real market and a broken product. A sub-3.0 App Store rating and frequent crashes weren't edge cases — they were capping the total addressable market. The problem wasn't the audience; it was the experience they were being asked to tolerate.",
+    featuredSections: [
+      {
+        lead: 'Benchmarking built the stakeholder confidence that unlocked the redesign.',
+        richTitle: 'Building the case for change',
+        body: [
+          "Six weeks. Skeptical stakeholders. A team that had shipped the original product and wasn't sure anything needed to change. Benchmarking gave us a shared language for what 'good' looked like — not opinions, but patterns from products the team already respected.",
+          "Once the case was made, the redesign ran in parallel with engineering's re-architecture — prototyping and testing each decision before handoff, so no one was waiting on anyone.",
+        ],
+        images: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/mock-ubiquiti.png'],
+      },
+      {
+        lead: 'App Store rating: below 3.0 to 4.5. Acquired for $500M+.',
+        richTitle: 'The numbers that followed',
+        body: [
+          "EASI surpassed 1M+ users and reached a $500M+ valuation. HungryPanda's acquisition rationale in 2022 mirrored the market strategy the redesign was built around — expanding from diaspora communities into a broader urban audience.",
+          "The six-week timeline wasn't a constraint. It was the discipline that kept the scope focused on what would move the numbers.",
+        ],
+        images: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/gf-blinkist.jpg'],
+      },
+    ],
+    mockups: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/gf-blinkist.jpg', '/images/portfolio/mock-ubiquiti.png'],
+    closingLead: 'A 4.5-star rating is a market signal. The $500M acquisition validated the strategy the redesign was built around.',
+    stats: [
+      { name: 'App Store rating', description: 'Climbed from below 3.0 to 4.5 stars following the redesign launch.', value: '3.0→4.5' },
+      { name: 'Users', description: 'EASI passed 1M+ users after the redesign expanded its addressable market.', value: '1M+' },
+      { name: 'Valuation at acquisition', description: 'HungryPanda acquired EASI in 2022 for a reported $500M+.', value: '$500M+' },
+    ],
+    tech: [
+      { k: 'Platform', v: 'iOS + Android' },
+      { k: 'Method', v: 'Benchmarking · prototype testing' },
+      { k: 'Timeline', v: '6 weeks' },
+    ],
+    tags: ['Consultant', 'Consumer', 'Mobile', 'iOS', 'Android', 'Benchmarking'],
+    credits: [
+      { role: 'Design consultant', name: 'Osandi Robinson' },
+      { role: 'Engineering', name: 'EASI engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'EASI' },
+      { role: 'PM', name: 'EASI product team' },
+    ],
+  },
+  {
+    slug: 'krisp-ai',
+    name: 'Krisp AI',
+    client: 'Krisp',
+    sector: 'AI',
+    year: '2020',
+    service: 'Consultant',
+    readTime: 3,
+    image: '/images/portfolio/gf-krisp.jpg',
+    headline: "Product innovation for Krisp.ai's noise cancelling desktop application",
+    intro:
+      "Krisp had strong utility and a dated interface. The noise cancellation worked. The desktop experience hadn't kept pace with what AI-native software was starting to look like — and that gap was starting to matter.",
+    featuredSections: [
+      {
+        lead: 'A modern UI system, not a reskin.',
+        richTitle: 'Redesigning for scale',
+        body: [
+          "Engaged as principal design consultant, I redesigned the application around a cohesive UI system — introducing branded components to accelerate implementation, reduce design debt, and establish a visual foundation capable of scaling with the product.",
+          "The work ran until COVID-19 created market uncertainty across the consumer audio space. What was scoped as a foundation for growth became a foundation for a pivot.",
+        ],
+        images: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-early-flow.png'],
+      },
+      {
+        lead: 'Krisp pivoted into meeting intelligence. The structural work held.',
+        richTitle: 'When the brief changes',
+        body: [
+          "The shift toward enterprise aesthetics and recording features was a different design brief than the original work was built to serve. But the component layer and the system thinking behind it gave the team a structured starting point for that evolution.",
+          "That's the value of system work over surface work — it outlives the original brief.",
+        ],
+        images: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-apple-genius.png'],
+      },
+    ],
+    mockups: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-early-flow.png', '/images/portfolio/mock-apple-genius.png'],
+    closingLead: 'System work outlives the brief it was built for. That\'s the difference between components and infrastructure.',
+    stats: [
+      { name: 'Engagement type', description: 'Engaged as principal design consultant for the desktop UI system redesign.', value: 'Principal' },
+    ],
+    tech: [
+      { k: 'Platform', v: 'Desktop (macOS + Windows)' },
+      { k: 'Method', v: 'UI system · component library' },
+    ],
+    tags: ['Consultant', 'AI', 'Desktop', 'Design systems', 'macOS', 'Windows'],
+    credits: [
+      { role: 'Design consultant', name: 'Osandi Robinson' },
+      { role: 'Engineering', name: 'Krisp engineering' },
+    ],
+    clientCredits: [
+      { role: 'Client', name: 'Krisp' },
+      { role: 'PM', name: 'Krisp product team' },
+    ],
+  },
+] as const;

--- a/src/mix1/pages/ProjectPage.tsx
+++ b/src/mix1/pages/ProjectPage.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+import { mix1Projects } from '../content';
+import { Mix1Contact } from '../Contact';
+import { Picture } from '../../studio/Picture';
+import { FigureStripes } from '../../studio/home/FigureStripes';
+
+export function ProjectPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const project = mix1Projects.find((p) => p.slug === slug);
+  const heroRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const hero = heroRef.current;
+    if (!hero) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        document.documentElement.classList.toggle('mix1-hero-visible', entry.isIntersecting);
+      },
+      { threshold: 0, rootMargin: '0px 0px -100% 0px' }
+    );
+    observer.observe(hero);
+    return () => {
+      observer.disconnect();
+      document.documentElement.classList.remove('mix1-hero-visible');
+    };
+  }, []);
+
+  if (!project) return <Navigate to="/mix1/work" replace />;
+
+  return (
+    <article className="page page-project mix1-project">
+      {/* ── Hero ─────────────────────────────────────────── */}
+      <section
+        ref={heroRef}
+        className="hero-project"
+        style={{ '--color-project': '#0f0f0f', '--site-color': '#ffffff' } as React.CSSProperties}
+      >
+        <div className="hero-project__inner">
+          <h1 className="heading heading--xl hero-project__title">{project.name}</h1>
+          <div className="hero-project__client">
+            <p className="hero-project__client-heading">Client</p>
+            <p className="hero-project__client-value">{project.client}</p>
+          </div>
+          <div className="hero-project__figure">
+            <div className="hero-project__sector-year">
+              <span>{project.sector}</span>
+              <span>/ {project.year}</span>
+            </div>
+            <FigureStripes src={project.image} alt={project.name} />
+          </div>
+          <div className="hero-project__services-readtime">
+            <div className="hero-project__services">
+              <ul>
+                <li>{project.service}</li>
+                {project.tags.map((tag) => (
+                  <li key={tag}>{tag}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="hero-project__readtime">
+              <p>{project.readTime} min</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Blocks ───────────────────────────────────────── */}
+      <div className="blocks blocks--ctx-project">
+        {/* Featured rich blocks interleaved with image blocks */}
+        {project.featuredSections.map((section, i) => (
+          <div key={i}>
+            {/* Block Featured Rich */}
+            <div className="block block--safe-area block--bg-light block-featured-rich block-featured-rich--ctx-project">
+              <div className="block-featured-rich__inner">
+                <div className="block-featured-rich__featured">
+                  <p>{section.lead}</p>
+                </div>
+                <div className="block-featured-rich__rich-content">
+                  <div className="rich-content">
+                    <h2>{section.richTitle}</h2>
+                    {section.body.map((para, pi) => (
+                      <p key={pi}>{para}</p>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Block Media — image grid */}
+            <div className="block block-media block--bg-light block--safe-area block-media--cols-2 block-media--ctx-project block-media--expansion-wrapper">
+              {section.images.map((src, ii) => (
+                <div key={ii} className="media block-media__item">
+                  <Picture src={src} alt="" className="picture--cover picture--rounded" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* Block Mockups — slider */}
+        <div className="block block-mockups block--has-background block-mockups--unique">
+          <div className="block-mockups__mockups">
+            <div className="slider slider-mockups slider--spv-auto">
+              <div className="swiper-wrapper">
+                {project.mockups.map((src, i) => (
+                  <div key={i} className="swiper-slide">
+                    <div className="block-mockups__mockup">
+                      <Picture src={src} alt="" className="picture--cover picture--rounded" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Closing featured (no rich content) */}
+        <div className="block block--safe-area block--bg-light block-featured-rich block-featured-rich--ctx-project">
+          <div className="block-featured-rich__inner">
+            <div className="block-featured-rich__featured">
+              <p>{project.closingLead}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Block Stats */}
+        {project.stats.length > 0 && (
+          <div className="block block--safe-area block--bg-light block-stats">
+            <div className="block-stats__inner">
+              <div className="block-stats__stats">
+                {project.stats.map((stat, i) => (
+                  <div key={i} className="block-stats__stat">
+                    <p className="block-stats__stat-name">{stat.name}</p>
+                    <p className="block-stats__stat-description">{stat.description}</p>
+                    <p className="block-stats__stat-value">{stat.value}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Credits ──────────────────────────────────────── */}
+      <section className="comp-credits">
+        <div className="comp-credits__inner">
+          <header className="comp-credits__header">
+            <h2 className="heading heading--md heading--dark heading--primary">Credits</h2>
+          </header>
+          <div className="comp-credits__start">
+            {project.credits.map((c) => (
+              <div key={c.role} className="comp-credits__group">
+                <div className="comp-credits__group-title">{c.role}</div>
+                <ul>
+                  <li>{c.name}</li>
+                </ul>
+              </div>
+            ))}
+          </div>
+          <div className="comp-credits__end">
+            {project.clientCredits.map((c) => (
+              <div key={c.role} className="comp-credits__group">
+                <div className="comp-credits__group-title">{c.role}</div>
+                <ul>
+                  <li>{c.name}</li>
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <Mix1Contact />
+    </article>
+  );
+}

--- a/src/mix1/pages/WorkPage.tsx
+++ b/src/mix1/pages/WorkPage.tsx
@@ -1,4 +1,5 @@
-import { mix1Work } from '../content';
+import { Link } from 'react-router-dom';
+import { mix1Work, mix1Projects } from '../content';
 import { Mix1Contact } from '../Contact';
 import { FigureStripes } from '../../studio/home/FigureStripes';
 import { SplitTextShuffle } from '../../studio/home/SplitTextShuffle';
@@ -39,21 +40,37 @@ export function WorkPage() {
         </div>
 
         <div className="list-article list-article--mode-default">
-          {mix1Work.items.map((item, index) => (
-            <article
-              key={item.name}
-              className={`article ${index % 2 === 0 ? 'article--header-dist-row' : 'article--header-dist-column'}`}
-            >
-              <FigureStripes src={item.image} alt={item.name} className="article__figure" />
-              <header>
-                <h2 className="heading heading--md article__heading">{item.name}</h2>
-                <p className="article__description">
-                  <strong>{item.headline}. </strong>
-                  {item.desc}
-                </p>
-              </header>
-            </article>
-          ))}
+          {mix1Work.items.map((item, index) => {
+            const project = mix1Projects.find((p) => p.name === item.name);
+            const inner = (
+              <>
+                <FigureStripes src={item.image} alt={item.name} className="article__figure" />
+                <header>
+                  <h2 className="heading heading--md article__heading">{item.name}</h2>
+                  <p className="article__description">
+                    <strong>{item.headline}. </strong>
+                    {item.desc}
+                  </p>
+                </header>
+              </>
+            );
+            return project ? (
+              <Link
+                key={item.name}
+                to={`/mix1/work/${project.slug}`}
+                className={`article ${index % 2 === 0 ? 'article--header-dist-row' : 'article--header-dist-column'}`}
+              >
+                {inner}
+              </Link>
+            ) : (
+              <article
+                key={item.name}
+                className={`article ${index % 2 === 0 ? 'article--header-dist-row' : 'article--header-dist-column'}`}
+              >
+                {inner}
+              </article>
+            );
+          })}
         </div>
       </div>
       <Mix1Contact />

--- a/src/mix1/styles/mix1.css
+++ b/src/mix1/styles/mix1.css
@@ -99,7 +99,7 @@ html[data-mix1] .mix1-nav {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  color: var(--color-primary);
+  color: var(--mix1-nav-color, var(--color-primary));
   pointer-events: none;
   font-family: var(--font-primary), sans-serif;
   font-size: var(--fs-navigation);
@@ -110,7 +110,7 @@ html[data-mix1] .mix1-nav {
 
 html[data-mix1] .mix1-nav a {
   pointer-events: all;
-  color: var(--color-primary);
+  color: var(--mix1-nav-color, var(--color-primary));
   text-decoration: none;
   font-family: inherit;
   font-size: inherit;
@@ -449,6 +449,14 @@ html[data-mix1][data-mix1-page='build'] .wkhs-root {
   padding-top: 3.5rem;
 }
 
+html[data-mix1][data-mix1-page='work-detail'].mix1-hero-visible {
+  --mix1-nav-color: #ffffff;
+}
+
+html[data-mix1][data-mix1-page='work-detail']:not(.mix1-hero-visible) {
+  --mix1-nav-color: var(--color-primary);
+}
+
 .mix1-impact {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -670,4 +678,843 @@ html[data-mix1][data-mix1-page='build'] .mix1-build__section > .mix1-pxbtn {
   html[data-mix1][data-mix1-page='home'] .tt-teaser {
     transition: none;
   }
+}
+
+/* ── Project detail page ─────────────────────────────── */
+
+html[data-mix1] .mix1-project__hero {
+  padding: calc(var(--wkhs-header-height) + var(--block-vpadding)) var(--safe-area) 0;
+}
+
+html[data-mix1] .mix1-project__hero-inner {
+  padding-bottom: calc(var(--block-vpadding) * 1.25);
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+  row-gap: var(--s4);
+}
+
+html[data-mix1] .mix1-project__meta {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-xs);
+  opacity: 0.55;
+  letter-spacing: 0.04em;
+}
+
+html[data-mix1] .mix1-project__heading {
+  grid-column: 1 / -1;
+}
+
+html[data-mix1] .mix1-project__headline {
+  grid-column: 1 / -1;
+  max-width: 52ch;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-lg);
+  margin: 0;
+}
+
+html[data-mix1] .mix1-project__figure {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+html[data-mix1] .mix1-project__figure .picture {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+}
+
+html[data-mix1] .mix1-project__service {
+  grid-column: 1 / -1;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .mix1-project__heading {
+    grid-column: 1 / span 8;
+  }
+
+  html[data-mix1] .mix1-project__headline {
+    grid-column: 1 / span 6;
+  }
+
+  html[data-mix1] .mix1-project__figure {
+    grid-column: 1 / span 9;
+  }
+
+  html[data-mix1] .mix1-project__figure .picture {
+    aspect-ratio: 4 / 3;
+  }
+
+  html[data-mix1] .mix1-project__service {
+    grid-column: 10 / -1;
+    align-self: end;
+  }
+}
+
+html[data-mix1] .mix1-project__body {
+  border-top: 1px solid var(--color-primary);
+}
+
+html[data-mix1] .mix1-project__section {
+  padding: var(--block-vpadding) var(--safe-area);
+  border-top: 1px solid var(--color-primary);
+}
+
+html[data-mix1] .mix1-project__section--rows {
+  padding-top: calc(var(--block-vpadding) * 0.75);
+}
+
+html[data-mix1] .mix1-project__section .heading--xl {
+  margin-bottom: 1rem;
+}
+
+html[data-mix1] .mix1-project__copy {
+  max-width: 62ch;
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+  margin: 0;
+}
+
+html[data-mix1] .mix1-project__metrics {
+  padding: var(--block-vpadding) var(--safe-area);
+  border-top: 1px solid var(--color-primary);
+}
+
+/* Make work cards clickable */
+html[data-mix1] a.article {
+  display: grid;
+  text-decoration: none;
+  color: inherit;
+}
+
+html[data-mix1] a.article:hover .article__heading {
+  opacity: 0.6;
+}
+
+/* ── Project intro blurb ─────────────────────────────── */
+
+html[data-mix1] .mix1-project__intro-wrap {
+  padding: var(--block-vpadding) var(--safe-area);
+  border-top: 1px solid var(--color-primary);
+}
+
+html[data-mix1] .mix1-project__intro {
+  max-width: 62ch;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-lg);
+  margin: 0;
+}
+
+/* ── Featured + rich sections ────────────────────────── */
+
+html[data-mix1] .mix1-project__featured-block {
+  border-top: 1px solid var(--color-primary);
+}
+
+html[data-mix1] .mix1-project__featured-rich {
+  padding: var(--block-vpadding) var(--safe-area);
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+}
+
+html[data-mix1] .mix1-project__featured-lead {
+  grid-column: 1 / -1;
+  font-size: var(--fs-xl);
+  line-height: var(--lh-xl);
+  margin: 0 0 calc(var(--block-vpadding) * 1.25);
+}
+
+html[data-mix1] .mix1-project__rich-content {
+  grid-column: 1 / -1;
+  max-width: 62ch;
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+}
+
+html[data-mix1] .mix1-project__rich-content p {
+  margin: 0;
+}
+
+html[data-mix1] .mix1-project__rich-content p + p {
+  margin-top: 1em;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .mix1-project__featured-lead {
+    grid-column: 1 / span 9;
+    font-size: var(--fs-xl);
+    text-indent: 3em;
+  }
+
+  html[data-mix1] .mix1-project__rich-content {
+    grid-column: 7 / span 6;
+  }
+}
+
+/* ── Image grid (inside featured block) ─────────────── */
+
+html[data-mix1] .mix1-project__image-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+  row-gap: var(--gap);
+  padding: 0 var(--safe-area) var(--block-vpadding);
+}
+
+html[data-mix1] .mix1-project__image-item {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+html[data-mix1] .mix1-project__image-item .picture {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .mix1-project__image-item:first-child:not(:only-child) {
+    grid-column: 1 / span 7;
+  }
+
+  html[data-mix1] .mix1-project__image-item:nth-child(2) {
+    grid-column: 8 / span 5;
+  }
+
+  html[data-mix1] .mix1-project__image-item:nth-child(3) {
+    grid-column: 1 / span 4;
+  }
+
+  html[data-mix1] .mix1-project__image-item:only-child {
+    grid-column: 1 / -1;
+  }
+}
+
+/* ── Mockup slider ───────────────────────────────────── */
+
+html[data-mix1] .mix1-project__mockups {
+  border-top: 1px solid var(--color-primary);
+  padding: var(--block-vpadding) 0;
+  overflow: hidden;
+}
+
+html[data-mix1] .mix1-project__mockups-track {
+  display: flex;
+  gap: var(--gap);
+  padding: 0 var(--safe-area);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+html[data-mix1] .mix1-project__mockups-track::-webkit-scrollbar {
+  display: none;
+}
+
+html[data-mix1] .mix1-project__mockup-slide {
+  flex: 0 0 min(72vw, 480px);
+  margin: 0;
+  scroll-snap-align: start;
+}
+
+html[data-mix1] .mix1-project__mockup-slide .picture {
+  aspect-ratio: 4 / 3;
+  width: 100%;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .mix1-project__mockup-slide {
+    flex: 0 0 min(40vw, 560px);
+  }
+}
+
+/* ── Awards ─────────────────────────────────────────── */
+
+html[data-mix1] .mix1-project__awards {
+  border-top: 1px solid var(--color-primary);
+  padding: var(--block-vpadding) var(--safe-area);
+}
+
+html[data-mix1] .mix1-project__award-item {
+  display: grid;
+  grid-template-columns: minmax(7rem, 12rem) minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1.1rem 0;
+  border-top: 1px solid var(--color-primary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+}
+
+html[data-mix1] .mix1-project__award-item:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+/* ── "See all work" CTA ──────────────────────────────── */
+
+html[data-mix1] .mix1-project__next {
+  padding: var(--block-vpadding) var(--safe-area);
+  border-top: 1px solid var(--color-primary);
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Project Detail — Bilbao-pattern classes
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Block utilities ────────────────────────────────────── */
+
+html[data-mix1] .block {
+  padding-top: var(--block-vpadding);
+  padding-bottom: var(--block-vpadding);
+}
+
+html[data-mix1] .block--safe-area {
+  padding-right: var(--safe-area);
+  padding-left: var(--safe-area);
+}
+
+html[data-mix1] .block--has-background + .block:not(.block--has-background) {
+  padding-top: calc(var(--block-vpadding) * 2);
+}
+
+html[data-mix1] .block:not(.block--has-background):has(+ .block--has-background) {
+  padding-bottom: calc(var(--block-vpadding) * 2);
+}
+
+/* ── Hero Project ───────────────────────────────────────── */
+
+html[data-mix1] .hero-project {
+  padding: calc(var(--wkhs-header-height)) var(--safe-area) 0;
+  background-color: var(--color-project, #0f0f0f);
+  color: var(--site-color, #fff);
+}
+
+html[data-mix1] .hero-project__inner {
+  padding: 1.5em 0 calc(var(--block-vpadding) * 2);
+  font-size: var(--fs-xl);
+  line-height: var(--lh-xl);
+  letter-spacing: var(--ls-xl);
+  display: grid;
+  grid-template-areas:
+    "c c c c c c c c"
+    "t t t t t t t t"
+    "f f f f f f f f"
+    "s s s s s s s s";
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+  color: var(--site-color, var(--color-primary));
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .hero-project__inner {
+    grid-template-areas:
+      "t t t t t t t . c c c c"
+      "f f f f f f . . s s s s";
+    row-gap: 3em;
+    padding: 1.25em 0 calc(var(--block-vpadding) * 2);
+  }
+}
+
+html[data-mix1] .hero-project__inner > *:not(.hero-project__title) {
+  font-size: var(--fs-base);
+  line-height: var(--lh-base);
+  letter-spacing: var(--ls-base);
+}
+
+html[data-mix1] .hero-project__title {
+  grid-area: t;
+  text-wrap: initial;
+  color: var(--site-color, var(--color-primary));
+}
+
+html[data-mix1] .hero-project__sector-year {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-sm);
+  letter-spacing: var(--ls-sm);
+  margin-bottom: 0.75em;
+  opacity: 0.6;
+}
+
+html[data-mix1] .hero-project__client {
+  grid-area: c;
+  margin-bottom: 2em;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .hero-project__client {
+    margin-top: 0.5em;
+    margin-bottom: 0;
+  }
+}
+
+html[data-mix1] .hero-project__client-heading {
+  display: none;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .hero-project__client-heading {
+    display: block;
+  }
+}
+
+html[data-mix1] .hero-project__client-value {
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+  letter-spacing: var(--ls-md);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .hero-project__client-value {
+    margin-top: 0.4em;
+  }
+}
+
+html[data-mix1] .hero-project__figure {
+  grid-area: f;
+  margin-top: 2em;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .hero-project__figure {
+    margin-top: 0;
+  }
+}
+
+html[data-mix1] .hero-project__figure .picture {
+  aspect-ratio: 99 / 124;
+}
+
+html[data-mix1] .hero-project__services-readtime {
+  grid-area: s;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 1em;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .hero-project__services-readtime {
+    flex-direction: column;
+    margin-top: 0;
+  }
+}
+
+html[data-mix1] .hero-project__readtime {
+  line-height: 0.8;
+}
+
+html[data-mix1] .hero-project__services ul {
+  margin-top: 1em;
+  list-style: none;
+  padding: 0;
+}
+
+/* ── Rich content ───────────────────────────────────────── */
+
+html[data-mix1] .rich-content {
+  --p-after-heading-margin-top: 1.5em;
+}
+
+html[data-mix1] .rich-content h2 + p {
+  margin-top: var(--p-after-heading-margin-top);
+}
+
+html[data-mix1] .rich-content p + p {
+  margin-top: 1em;
+}
+
+html[data-mix1] .rich-content h2 {
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+  letter-spacing: var(--ls-md);
+  margin-bottom: 0.6em;
+  text-transform: uppercase;
+}
+
+/* ── Block Featured Rich ────────────────────────────────── */
+
+html[data-mix1] .block-featured-rich__inner {
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+}
+
+html[data-mix1] .block-featured-rich__featured {
+  grid-column: span var(--cols);
+  font-size: var(--fs-lg);
+  line-height: var(--lh-lg);
+  letter-spacing: var(--ls-lg);
+}
+
+html[data-mix1] .block-featured-rich__featured:has(+ .block-featured-rich__rich-content) {
+  margin-bottom: calc(var(--block-vpadding) * 2);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-featured-rich__featured p {
+    text-indent: 3em;
+  }
+}
+
+html[data-mix1] .block-featured-rich__rich-content {
+  grid-column: span var(--cols);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-featured-rich__rich-content {
+    grid-column: span 9;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  html[data-mix1] .block-featured-rich__rich-content {
+    grid-column: 7 / span 6;
+  }
+}
+
+/* ── Block Media ────────────────────────────────────────── */
+
+html[data-mix1] .block-media {
+  --item-grid-column: span 12;
+  --block-media-aspect-ratio: unset;
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+  row-gap: var(--gap);
+}
+
+html[data-mix1] .block-media--cols-2 {
+  --item-grid-column: span 6;
+  --block-media-aspect-ratio: 351 / 442;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-media--cols-2 {
+    --block-media-aspect-ratio: 686 / 868;
+  }
+}
+
+html[data-mix1] .block-media__item {
+  grid-column: var(--item-grid-column);
+}
+
+html[data-mix1] .block-media__item .picture {
+  aspect-ratio: var(--block-media-aspect-ratio);
+}
+
+html[data-mix1] .block-media.block-media--ctx-project.block-media--cols-2 {
+  --item-grid-column: span var(--cols);
+  row-gap: var(--gap);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-media.block-media--ctx-project.block-media--cols-2 {
+    --item-grid-column: span 6;
+  }
+}
+
+/* ── Block Mockups ──────────────────────────────────────── */
+
+html[data-mix1] .block-mockups {
+  padding-top: calc(var(--block-vpadding) * 2);
+  padding-bottom: calc(var(--block-vpadding) * 2);
+  max-width: 100%;
+  overflow: hidden;
+  position: relative;
+  padding-left: var(--safe-area);
+  padding-right: var(--safe-area);
+  background-color: var(--color-bg-alt, #f5f4f0);
+}
+
+html[data-mix1] .block-mockups__mockups {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 100%;
+}
+
+html[data-mix1] .block-mockups__mockups .slider {
+  width: 100%;
+  display: flex;
+  gap: var(--gap);
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  margin: 0 calc(var(--safe-area) * -1);
+  padding: 0 var(--safe-area);
+}
+
+html[data-mix1] .block-mockups__mockups .slider::-webkit-scrollbar {
+  display: none;
+}
+
+html[data-mix1] .block-mockups__mockups .swiper-wrapper {
+  display: flex;
+  gap: var(--gap);
+  align-items: stretch;
+}
+
+html[data-mix1] .block-mockups--unique .block-mockups__mockups .swiper-wrapper {
+  justify-content: center;
+}
+
+html[data-mix1] .block-mockups__mockups .swiper-slide {
+  flex-shrink: 0;
+  width: 60vw;
+  scroll-snap-align: start;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-mockups__mockups .swiper-slide {
+    width: calc(3 * 100 / var(--cols) * 1%);
+  }
+}
+
+html[data-mix1] .block-mockups__mockup {
+  height: 100%;
+}
+
+html[data-mix1] .block-mockups__mockup .picture {
+  aspect-ratio: 9 / 16;
+  border-radius: 0.5rem;
+}
+
+/* ── Block Stats ────────────────────────────────────────── */
+
+html[data-mix1] .block-stats {
+  /* inherits block padding */
+}
+
+html[data-mix1] .block-stats__inner {
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+}
+
+html[data-mix1] .block-stats__stats {
+  display: grid;
+  grid-template-columns: subgrid;
+  column-gap: var(--gap);
+  grid-column: span var(--cols);
+}
+
+html[data-mix1] .block-stats__stat {
+  display: grid;
+  grid-template-columns: subgrid;
+  column-gap: var(--gap);
+  grid-column: span var(--cols);
+  border-top: 1px solid var(--color-primary);
+  padding: 1em 0;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-stats__stat {
+    border-top: none;
+    border-bottom: 1px solid var(--color-primary);
+  }
+}
+
+html[data-mix1] .block-stats__stat-name {
+  grid-column: span var(--cols);
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+  letter-spacing: var(--ls-md);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-stats__stat-name {
+    grid-column: span 4;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  html[data-mix1] .block-stats__stat-name {
+    grid-column: span 6;
+  }
+}
+
+html[data-mix1] .block-stats__stat-description {
+  margin: 1em 0 0.5em;
+  grid-column: span var(--cols);
+  color: var(--color-secondary, #666);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-stats__stat-description {
+    grid-column: span 4;
+    margin: 0;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  html[data-mix1] .block-stats__stat-description {
+    grid-column: span 3;
+  }
+}
+
+html[data-mix1] .block-stats__stat-value {
+  grid-column: span var(--cols);
+  font-size: var(--fs-xl);
+  line-height: var(--lh-xl);
+  letter-spacing: var(--ls-xl);
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .block-stats__stat-value {
+    grid-column: 9 / span 4;
+    text-align: right;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  html[data-mix1] .block-stats__stat-value {
+    grid-column: 10 / span 3;
+  }
+}
+
+/* ── Comp Credits ───────────────────────────────────────── */
+
+html[data-mix1] .comp-credits {
+  padding: var(--block-vpadding) var(--safe-area) calc(var(--block-vpadding) * 2);
+  background-color: var(--color-primary);
+  color: var(--color-primary-contrast, #fff);
+}
+
+html[data-mix1] .comp-credits .heading {
+  text-transform: uppercase;
+}
+
+html[data-mix1] .comp-credits__inner {
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  column-gap: var(--gap);
+}
+
+html[data-mix1] .comp-credits__header {
+  grid-column: span var(--cols);
+  margin-bottom: 2.3em;
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+  letter-spacing: var(--ls-md);
+}
+
+html[data-mix1] .comp-credits__start,
+html[data-mix1] .comp-credits__end {
+  grid-column: span var(--cols);
+  display: grid;
+  grid-template-columns: subgrid;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .comp-credits__start {
+    grid-column: span 6;
+  }
+
+  html[data-mix1] .comp-credits__end {
+    grid-column: 7 / span 6;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  html[data-mix1] .comp-credits__start {
+    grid-column: 5 / span 4;
+  }
+
+  html[data-mix1] .comp-credits__end {
+    grid-column: 10 / span 3;
+  }
+}
+
+html[data-mix1] .comp-credits__group {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: span var(--cols);
+  margin-top: 2em;
+}
+
+html[data-mix1] .comp-credits__start > .comp-credits__group:first-child {
+  margin-top: 0;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .comp-credits__group {
+    grid-column: span 6;
+    margin-top: 0;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  html[data-mix1] .comp-credits__group {
+    grid-column: span 4;
+  }
+}
+
+html[data-mix1] .comp-credits__group + .comp-credits__group {
+  margin-top: 2em;
+}
+
+html[data-mix1] .comp-credits__group-title {
+  grid-column: span 3;
+  opacity: 0.6;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .comp-credits__group-title {
+    grid-column: span 3;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  html[data-mix1] .comp-credits__group-title {
+    grid-column: span 2;
+  }
+}
+
+html[data-mix1] .comp-credits__group ul {
+  grid-column: span 5;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+@media screen and (min-width: 768px) {
+  html[data-mix1] .comp-credits__group ul {
+    grid-column: span 3;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  html[data-mix1] .comp-credits__group ul {
+    grid-column: span 2;
+  }
+}
+
+html[data-mix1] .comp-credits ul li {
+  font-size: var(--fs-md);
+  line-height: var(--lh-md);
+  letter-spacing: var(--ls-md);
+}
+
+html[data-mix1] .comp-credits ul li + li {
+  margin-top: 0.2em;
+}
+
+
+/* ── Contact banner overrides for mix1 ──────────────────── */
+
+html[data-mix1] .contact-banner {
+  /* inherits vendor contact-banner styles */
+  border-top: 1px solid var(--color-primary);
 }

--- a/src/mix1/usePrefersReducedMotion.ts
+++ b/src/mix1/usePrefersReducedMotion.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from 'react';
+
+const query = '(prefers-reduced-motion: reduce)';
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(query);
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+}
+
+export function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+}


### PR DESCRIPTION
- New ProjectPage component with hero, block-featured-rich, block-media, block-mockups, block-stats, comp-credits sections matching Workoholics reference
- Added mix1Projects data for all 7 projects with credits, tags, stats
- WorkPage cards now link to /mix1/work/:slug
- App.tsx route + Mix1Shell work-detail page type
- White nav on dark hero, auto-switches black on scroll past
- Fixed FigureStripes broken imports in src/mix1