### PR TITLE
Add test-assets toggle for aspect-ratio-matched placeholder content

### DIFF
--- a/public/images/placeholder-mix1/ratio-1024x1024.svg
+++ b/public/images/placeholder-mix1/ratio-1024x1024.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="51" fill="#090909" letter-spacing="2">1:1</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="30" fill="rgba(9,9,9,0.55)" letter-spacing="2">1024x1024</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-1024x1024.svg
+++ b/public/images/placeholder-mix1/ratio-1024x1024.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
-  <rect width="1024" height="1024" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="51" fill="#090909" letter-spacing="2">1:1</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="30" fill="rgba(9,9,9,0.55)" letter-spacing="2">1024x1024</text>
+  <rect width="1024" height="1024" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="51" fill="#f9f8f5" letter-spacing="2">1:1</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="30" fill="rgba(249,248,245,0.55)" letter-spacing="2">1024x1024</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-1320x2868.svg
+++ b/public/images/placeholder-mix1/ratio-1320x2868.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="660" height="1434" viewBox="0 0 660 1434">
-  <rect width="660" height="1434" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="33" fill="#090909" letter-spacing="2">1320:2868</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="19" fill="rgba(9,9,9,0.55)" letter-spacing="2">660x1434</text>
+  <rect width="660" height="1434" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="33" fill="#f9f8f5" letter-spacing="2">1320:2868</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="19" fill="rgba(249,248,245,0.55)" letter-spacing="2">660x1434</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-1320x2868.svg
+++ b/public/images/placeholder-mix1/ratio-1320x2868.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="1434" viewBox="0 0 660 1434">
+  <rect width="660" height="1434" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="33" fill="#090909" letter-spacing="2">1320:2868</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="19" fill="rgba(9,9,9,0.55)" letter-spacing="2">660x1434</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-1603x2400.svg
+++ b/public/images/placeholder-mix1/ratio-1603x2400.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="802" height="1200" viewBox="0 0 802 1200">
-  <rect width="802" height="1200" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="40" fill="#090909" letter-spacing="2">1603:2400</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(9,9,9,0.55)" letter-spacing="2">802x1200</text>
+  <rect width="802" height="1200" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="40" fill="#f9f8f5" letter-spacing="2">1603:2400</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">802x1200</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-1603x2400.svg
+++ b/public/images/placeholder-mix1/ratio-1603x2400.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="802" height="1200" viewBox="0 0 802 1200">
+  <rect width="802" height="1200" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="40" fill="#090909" letter-spacing="2">1603:2400</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(9,9,9,0.55)" letter-spacing="2">802x1200</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-214x290.svg
+++ b/public/images/placeholder-mix1/ratio-214x290.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="856" height="1160" viewBox="0 0 856 1160">
-  <rect width="856" height="1160" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="42" fill="#090909" letter-spacing="2">214:290</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="25" fill="rgba(9,9,9,0.55)" letter-spacing="2">856x1160</text>
+  <rect width="856" height="1160" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="42" fill="#f9f8f5" letter-spacing="2">214:290</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="25" fill="rgba(249,248,245,0.55)" letter-spacing="2">856x1160</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-214x290.svg
+++ b/public/images/placeholder-mix1/ratio-214x290.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="856" height="1160" viewBox="0 0 856 1160">
+  <rect width="856" height="1160" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="42" fill="#090909" letter-spacing="2">214:290</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="25" fill="rgba(9,9,9,0.55)" letter-spacing="2">856x1160</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-451x567.svg
+++ b/public/images/placeholder-mix1/ratio-451x567.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="902" height="1134" viewBox="0 0 902 1134">
-  <rect width="902" height="1134" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#090909" letter-spacing="2">451:567</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(9,9,9,0.55)" letter-spacing="2">902x1134</text>
+  <rect width="902" height="1134" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#f9f8f5" letter-spacing="2">451:567</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(249,248,245,0.55)" letter-spacing="2">902x1134</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-451x567.svg
+++ b/public/images/placeholder-mix1/ratio-451x567.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="902" height="1134" viewBox="0 0 902 1134">
+  <rect width="902" height="1134" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#090909" letter-spacing="2">451:567</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(9,9,9,0.55)" letter-spacing="2">902x1134</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-686x868.svg
+++ b/public/images/placeholder-mix1/ratio-686x868.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="686" height="868" viewBox="0 0 686 868">
+  <rect width="686" height="868" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="34" fill="#090909" letter-spacing="2">686:868</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="20" fill="rgba(9,9,9,0.55)" letter-spacing="2">686x868</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-686x868.svg
+++ b/public/images/placeholder-mix1/ratio-686x868.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="686" height="868" viewBox="0 0 686 868">
-  <rect width="686" height="868" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="34" fill="#090909" letter-spacing="2">686:868</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="20" fill="rgba(9,9,9,0.55)" letter-spacing="2">686x868</text>
+  <rect width="686" height="868" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="34" fill="#f9f8f5" letter-spacing="2">686:868</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="20" fill="rgba(249,248,245,0.55)" letter-spacing="2">686x868</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-900x1600.svg
+++ b/public/images/placeholder-mix1/ratio-900x1600.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="1600" viewBox="0 0 900 1600">
+  <rect width="900" height="1600" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#090909" letter-spacing="2">9:16</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(9,9,9,0.55)" letter-spacing="2">900x1600</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-900x1600.svg
+++ b/public/images/placeholder-mix1/ratio-900x1600.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="900" height="1600" viewBox="0 0 900 1600">
-  <rect width="900" height="1600" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#090909" letter-spacing="2">9:16</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(9,9,9,0.55)" letter-spacing="2">900x1600</text>
+  <rect width="900" height="1600" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#f9f8f5" letter-spacing="2">9:16</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(249,248,245,0.55)" letter-spacing="2">900x1600</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-99x124.svg
+++ b/public/images/placeholder-mix1/ratio-99x124.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="792" height="992" viewBox="0 0 792 992">
-  <rect width="792" height="992" fill="#f9f8f5"/>
-  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#090909" letter-spacing="2">99:124</text>
-  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(9,9,9,0.55)" letter-spacing="2">792x992</text>
+  <rect width="792" height="992" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#f9f8f5" letter-spacing="2">99:124</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">792x992</text>
 </svg>

--- a/public/images/placeholder-mix1/ratio-99x124.svg
+++ b/public/images/placeholder-mix1/ratio-99x124.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="792" height="992" viewBox="0 0 792 992">
+  <rect width="792" height="992" fill="#f9f8f5"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#090909" letter-spacing="2">99:124</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(9,9,9,0.55)" letter-spacing="2">792x992</text>
+</svg>

--- a/public/images/placeholder/ratio-16x10-01.svg
+++ b/public/images/placeholder/ratio-16x10-01.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3840" height="2426" viewBox="0 0 3840 2426">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="320" height="320" patternUnits="userSpaceOnUse">
+      <path d="M 320 0 L 0 0 0 320" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="3840" height="2426" fill="url(#g)"/>
+  <rect width="3840" height="2426" fill="url(#grid)"/>
+  <rect x="96" y="60" width="3648" height="2305" fill="none" stroke="#ff3b3b" stroke-width="11" stroke-dasharray="64 32"/>
+  <circle cx="1920" cy="1040" r="174" fill="none" stroke="#ff3b3b" stroke-width="14"/>
+  <line x1="1783" y1="1040" x2="2057" y2="1040" stroke="#ff3b3b" stroke-width="14"/>
+  <line x1="1920" y1="903" x2="1920" y2="1177" stroke="#ff3b3b" stroke-width="14"/>
+  <text x="50%" y="1482" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="147" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1707" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="112" fill="rgba(234,230,221,0.5)" letter-spacing="2">16:10 · #01</text>
+  <text x="50%" y="2316" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="96" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 3840x2426</text>
+</svg>

--- a/public/images/placeholder/ratio-16x10-02.svg
+++ b/public/images/placeholder/ratio-16x10-02.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3840" height="2426" viewBox="0 0 3840 2426">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="320" height="320" patternUnits="userSpaceOnUse">
+      <path d="M 320 0 L 0 0 0 320" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="3840" height="2426" fill="url(#g)"/>
+  <rect width="3840" height="2426" fill="url(#grid)"/>
+  <rect x="96" y="60" width="3648" height="2305" fill="none" stroke="#ff3b3b" stroke-width="11" stroke-dasharray="64 32"/>
+  <circle cx="1920" cy="1040" r="174" fill="none" stroke="#ff3b3b" stroke-width="14"/>
+  <line x1="1783" y1="1040" x2="2057" y2="1040" stroke="#ff3b3b" stroke-width="14"/>
+  <line x1="1920" y1="903" x2="1920" y2="1177" stroke="#ff3b3b" stroke-width="14"/>
+  <text x="50%" y="1482" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="147" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1707" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="112" fill="rgba(234,230,221,0.5)" letter-spacing="2">16:10 · #02</text>
+  <text x="50%" y="2316" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="96" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 3840x2426</text>
+</svg>

--- a/public/images/placeholder/ratio-16x10-03.svg
+++ b/public/images/placeholder/ratio-16x10-03.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="3840" height="2426" viewBox="0 0 3840 2426">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="320" height="320" patternUnits="userSpaceOnUse">
+      <path d="M 320 0 L 0 0 0 320" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="3840" height="2426" fill="url(#g)"/>
+  <rect width="3840" height="2426" fill="url(#grid)"/>
+  <rect x="96" y="60" width="3648" height="2305" fill="none" stroke="#ff3b3b" stroke-width="11" stroke-dasharray="64 32"/>
+  <circle cx="1920" cy="1040" r="174" fill="none" stroke="#ff3b3b" stroke-width="14"/>
+  <line x1="1783" y1="1040" x2="2057" y2="1040" stroke="#ff3b3b" stroke-width="14"/>
+  <line x1="1920" y1="903" x2="1920" y2="1177" stroke="#ff3b3b" stroke-width="14"/>
+  <text x="50%" y="1482" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="147" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1707" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="112" fill="rgba(234,230,221,0.5)" letter-spacing="2">16:10 · #03</text>
+  <text x="50%" y="2316" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="96" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 3840x2426</text>
+</svg>

--- a/public/images/placeholder/ratio-16x9-01.svg
+++ b/public/images/placeholder/ratio-16x9-01.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1440" viewBox="0 0 2560 1440">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="213" height="213" patternUnits="userSpaceOnUse">
+      <path d="M 213 0 L 0 0 0 213" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2560" height="1440" fill="url(#g)"/>
+  <rect width="2560" height="1440" fill="url(#grid)"/>
+  <rect x="64" y="36" width="2432" height="1368" fill="none" stroke="#ff3b3b" stroke-width="8" stroke-dasharray="42 21"/>
+  <circle cx="1280" cy="618" r="116" fill="none" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1189" y1="618" x2="1371" y2="618" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1280" y1="527" x2="1280" y2="709" stroke="#ff3b3b" stroke-width="10"/>
+  <text x="50%" y="880" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="98" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1030" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="75" fill="rgba(234,230,221,0.5)" letter-spacing="2">16:9 · #01</text>
+  <text x="50%" y="1375" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="64" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2560x1440</text>
+</svg>

--- a/public/images/placeholder/ratio-16x9-02.svg
+++ b/public/images/placeholder/ratio-16x9-02.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1440" viewBox="0 0 2560 1440">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="213" height="213" patternUnits="userSpaceOnUse">
+      <path d="M 213 0 L 0 0 0 213" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2560" height="1440" fill="url(#g)"/>
+  <rect width="2560" height="1440" fill="url(#grid)"/>
+  <rect x="64" y="36" width="2432" height="1368" fill="none" stroke="#ff3b3b" stroke-width="8" stroke-dasharray="42 21"/>
+  <circle cx="1280" cy="618" r="116" fill="none" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1189" y1="618" x2="1371" y2="618" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1280" y1="527" x2="1280" y2="709" stroke="#ff3b3b" stroke-width="10"/>
+  <text x="50%" y="880" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="98" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1030" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="75" fill="rgba(234,230,221,0.5)" letter-spacing="2">16:9 · #02</text>
+  <text x="50%" y="1375" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="64" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2560x1440</text>
+</svg>

--- a/public/images/placeholder/ratio-4x5-01.svg
+++ b/public/images/placeholder/ratio-4x5-01.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2560" viewBox="0 0 2048 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="170" height="170" patternUnits="userSpaceOnUse">
+      <path d="M 170 0 L 0 0 0 170" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2048" height="2560" fill="url(#g)"/>
+  <rect width="2048" height="2560" fill="url(#grid)"/>
+  <rect x="51" y="64" width="1946" height="2432" fill="none" stroke="#ff3b3b" stroke-width="7" stroke-dasharray="34 17"/>
+  <circle cx="1024" cy="1098" r="93" fill="none" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="951" y1="1098" x2="1097" y2="1098" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="1024" y1="1025" x2="1024" y2="1171" stroke="#ff3b3b" stroke-width="8"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="78" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1684" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="60" fill="rgba(234,230,221,0.5)" letter-spacing="2">4:5 · #01</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="51" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2048x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-4x5-02.svg
+++ b/public/images/placeholder/ratio-4x5-02.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2560" viewBox="0 0 2048 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="170" height="170" patternUnits="userSpaceOnUse">
+      <path d="M 170 0 L 0 0 0 170" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2048" height="2560" fill="url(#g)"/>
+  <rect width="2048" height="2560" fill="url(#grid)"/>
+  <rect x="51" y="64" width="1946" height="2432" fill="none" stroke="#ff3b3b" stroke-width="7" stroke-dasharray="34 17"/>
+  <circle cx="1024" cy="1098" r="93" fill="none" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="951" y1="1098" x2="1097" y2="1098" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="1024" y1="1025" x2="1024" y2="1171" stroke="#ff3b3b" stroke-width="8"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="78" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1684" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="60" fill="rgba(234,230,221,0.5)" letter-spacing="2">4:5 · #02</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="51" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2048x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-4x5-03.svg
+++ b/public/images/placeholder/ratio-4x5-03.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2560" viewBox="0 0 2048 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="170" height="170" patternUnits="userSpaceOnUse">
+      <path d="M 170 0 L 0 0 0 170" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2048" height="2560" fill="url(#g)"/>
+  <rect width="2048" height="2560" fill="url(#grid)"/>
+  <rect x="51" y="64" width="1946" height="2432" fill="none" stroke="#ff3b3b" stroke-width="7" stroke-dasharray="34 17"/>
+  <circle cx="1024" cy="1098" r="93" fill="none" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="951" y1="1098" x2="1097" y2="1098" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="1024" y1="1025" x2="1024" y2="1171" stroke="#ff3b3b" stroke-width="8"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="78" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1684" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="60" fill="rgba(234,230,221,0.5)" letter-spacing="2">4:5 · #03</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="51" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2048x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-4x5-04.svg
+++ b/public/images/placeholder/ratio-4x5-04.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2560" viewBox="0 0 2048 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="170" height="170" patternUnits="userSpaceOnUse">
+      <path d="M 170 0 L 0 0 0 170" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2048" height="2560" fill="url(#g)"/>
+  <rect width="2048" height="2560" fill="url(#grid)"/>
+  <rect x="51" y="64" width="1946" height="2432" fill="none" stroke="#ff3b3b" stroke-width="7" stroke-dasharray="34 17"/>
+  <circle cx="1024" cy="1098" r="93" fill="none" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="951" y1="1098" x2="1097" y2="1098" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="1024" y1="1025" x2="1024" y2="1171" stroke="#ff3b3b" stroke-width="8"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="78" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1684" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="60" fill="rgba(234,230,221,0.5)" letter-spacing="2">4:5 · #04</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="51" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2048x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-4x5-05.svg
+++ b/public/images/placeholder/ratio-4x5-05.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2560" viewBox="0 0 2048 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="170" height="170" patternUnits="userSpaceOnUse">
+      <path d="M 170 0 L 0 0 0 170" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2048" height="2560" fill="url(#g)"/>
+  <rect width="2048" height="2560" fill="url(#grid)"/>
+  <rect x="51" y="64" width="1946" height="2432" fill="none" stroke="#ff3b3b" stroke-width="7" stroke-dasharray="34 17"/>
+  <circle cx="1024" cy="1098" r="93" fill="none" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="951" y1="1098" x2="1097" y2="1098" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="1024" y1="1025" x2="1024" y2="1171" stroke="#ff3b3b" stroke-width="8"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="78" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1684" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="60" fill="rgba(234,230,221,0.5)" letter-spacing="2">4:5 · #05</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="51" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2048x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-4x5-06.svg
+++ b/public/images/placeholder/ratio-4x5-06.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="2560" viewBox="0 0 2048 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="170" height="170" patternUnits="userSpaceOnUse">
+      <path d="M 170 0 L 0 0 0 170" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2048" height="2560" fill="url(#g)"/>
+  <rect width="2048" height="2560" fill="url(#grid)"/>
+  <rect x="51" y="64" width="1946" height="2432" fill="none" stroke="#ff3b3b" stroke-width="7" stroke-dasharray="34 17"/>
+  <circle cx="1024" cy="1098" r="93" fill="none" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="951" y1="1098" x2="1097" y2="1098" stroke="#ff3b3b" stroke-width="8"/>
+  <line x1="1024" y1="1025" x2="1024" y2="1171" stroke="#ff3b3b" stroke-width="8"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="78" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1684" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="60" fill="rgba(234,230,221,0.5)" letter-spacing="2">4:5 · #06</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="51" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2048x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-square-01.svg
+++ b/public/images/placeholder/ratio-square-01.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="2560" viewBox="0 0 2560 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="213" height="213" patternUnits="userSpaceOnUse">
+      <path d="M 213 0 L 0 0 0 213" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2560" height="2560" fill="url(#g)"/>
+  <rect width="2560" height="2560" fill="url(#grid)"/>
+  <rect x="64" y="64" width="2432" height="2432" fill="none" stroke="#ff3b3b" stroke-width="8" stroke-dasharray="42 21"/>
+  <circle cx="1280" cy="1098" r="116" fill="none" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1189" y1="1098" x2="1371" y2="1098" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1280" y1="1007" x2="1280" y2="1189" stroke="#ff3b3b" stroke-width="10"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="98" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1714" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="75" fill="rgba(234,230,221,0.5)" letter-spacing="2">1:1 · #01</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="64" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2560x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-square-02.svg
+++ b/public/images/placeholder/ratio-square-02.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="2560" viewBox="0 0 2560 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="213" height="213" patternUnits="userSpaceOnUse">
+      <path d="M 213 0 L 0 0 0 213" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2560" height="2560" fill="url(#g)"/>
+  <rect width="2560" height="2560" fill="url(#grid)"/>
+  <rect x="64" y="64" width="2432" height="2432" fill="none" stroke="#ff3b3b" stroke-width="8" stroke-dasharray="42 21"/>
+  <circle cx="1280" cy="1098" r="116" fill="none" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1189" y1="1098" x2="1371" y2="1098" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1280" y1="1007" x2="1280" y2="1189" stroke="#ff3b3b" stroke-width="10"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="98" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1714" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="75" fill="rgba(234,230,221,0.5)" letter-spacing="2">1:1 · #02</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="64" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2560x2560</text>
+</svg>

--- a/public/images/placeholder/ratio-square-03.svg
+++ b/public/images/placeholder/ratio-square-03.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="2560" viewBox="0 0 2560 2560">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1c1a1a"/>
+      <stop offset="100%" stop-color="#0c0b0b"/>
+    </linearGradient>
+    <pattern id="grid" width="213" height="213" patternUnits="userSpaceOnUse">
+      <path d="M 213 0 L 0 0 0 213" fill="none" stroke="rgba(234,230,221,0.06)" stroke-width="2"/>
+    </pattern>
+  </defs>
+  <rect width="2560" height="2560" fill="url(#g)"/>
+  <rect width="2560" height="2560" fill="url(#grid)"/>
+  <rect x="64" y="64" width="2432" height="2432" fill="none" stroke="#ff3b3b" stroke-width="8" stroke-dasharray="42 21"/>
+  <circle cx="1280" cy="1098" r="116" fill="none" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1189" y1="1098" x2="1371" y2="1098" stroke="#ff3b3b" stroke-width="10"/>
+  <line x1="1280" y1="1007" x2="1280" y2="1189" stroke="#ff3b3b" stroke-width="10"/>
+  <text x="50%" y="1564" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="98" fill="#eae6dd" letter-spacing="2">PLACEHOLDER</text>
+  <text x="50%" y="1714" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="75" fill="rgba(234,230,221,0.5)" letter-spacing="2">1:1 · #03</text>
+  <text x="50%" y="2444" text-anchor="middle" font-family="IBM Plex Mono, monospace" font-size="64" fill="rgba(234,230,221,0.35)" letter-spacing="1">TEST ASSET · ISSUE #62 · 2560x2560</text>
+</svg>

--- a/src/components/chrome/PlaceholderToggle.tsx
+++ b/src/components/chrome/PlaceholderToggle.tsx
@@ -1,0 +1,17 @@
+import { togglePlaceholderAssets, usePlaceholderAssets } from '../../hooks/usePlaceholderAssets';
+
+export function PlaceholderToggle() {
+  const on = usePlaceholderAssets();
+
+  return (
+    <button
+      type="button"
+      className={`placeholder-toggle${on ? ' is-active' : ''}`}
+      onClick={() => togglePlaceholderAssets()}
+      aria-pressed={on}
+    >
+      <span className="placeholder-toggle-dot" aria-hidden />
+      {on ? 'TEST ASSETS · ON' : 'TEST ASSETS'}
+    </button>
+  );
+}

--- a/src/components/chrome/SiteShell.tsx
+++ b/src/components/chrome/SiteShell.tsx
@@ -5,6 +5,7 @@ import { FullscreenMenu } from './FullscreenMenu';
 import { ScrollProgressRail } from './ScrollProgressRail';
 import { FootCTA } from './FootCTA';
 import { SiteFooter } from './SiteFooter';
+import { PlaceholderToggle } from './PlaceholderToggle';
 import './chrome.css';
 
 export function SiteShell() {
@@ -25,6 +26,7 @@ export function SiteShell() {
       <FootCTA />
       <SiteFooter />
       <ScrollProgressRail />
+      <PlaceholderToggle />
     </>
   );
 }

--- a/src/components/chrome/chrome.css
+++ b/src/components/chrome/chrome.css
@@ -382,3 +382,50 @@
 .site-footer .footer-build:hover {
   color: var(--color-red);
 }
+
+/* ---------- PlaceholderToggle ---------- */
+.placeholder-toggle {
+  position: fixed;
+  left: var(--space-3);
+  bottom: var(--space-3);
+  z-index: var(--z-rail);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: rgba(12, 11, 11, 0.85);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--color-hair);
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-mono);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-fast) var(--ease-out),
+    color var(--motion-fast) var(--ease-out);
+}
+
+.placeholder-toggle:hover {
+  border-color: var(--color-red);
+  color: var(--color-paper);
+}
+
+.placeholder-toggle-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-hair);
+  transition: background var(--motion-fast) var(--ease-out);
+}
+
+.placeholder-toggle.is-active {
+  color: var(--color-red);
+  border-color: var(--color-red);
+}
+
+.placeholder-toggle.is-active .placeholder-toggle-dot {
+  background: var(--color-red);
+  animation: pulse 2.4s ease-in-out infinite;
+}

--- a/src/content/placeholderAssets.ts
+++ b/src/content/placeholderAssets.ts
@@ -1,0 +1,39 @@
+/**
+ * Test placeholder pool from GitHub issue #62, grouped by the aspect ratio
+ * that best matches each site slot (see MediaFrame/CSS aspect-ratio callers).
+ * Ratios not represented here (3:4 hero cells, 4:3 roll stage, 3:4 portraits)
+ * have no close match in the issue's assets and are left on real content.
+ */
+export const placeholderAssets = {
+  '4:5': [
+    '/images/placeholder/ratio-4x5-01.svg',
+    '/images/placeholder/ratio-4x5-02.svg',
+    '/images/placeholder/ratio-4x5-03.svg',
+    '/images/placeholder/ratio-4x5-04.svg',
+    '/images/placeholder/ratio-4x5-05.svg',
+    '/images/placeholder/ratio-4x5-06.svg',
+  ],
+  '16:10': [
+    '/images/placeholder/ratio-16x10-01.svg',
+    '/images/placeholder/ratio-16x10-02.svg',
+    '/images/placeholder/ratio-16x10-03.svg',
+  ],
+  '16:9': ['/images/placeholder/ratio-16x9-01.svg', '/images/placeholder/ratio-16x9-02.svg'],
+  square: ['/images/placeholder/ratio-square-01.svg', '/images/placeholder/ratio-square-02.svg', '/images/placeholder/ratio-square-03.svg'],
+} as const;
+
+export type PlaceholderRatio = keyof typeof placeholderAssets;
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+/** Deterministic pick so a given real src always resolves to the same placeholder. */
+export function pickPlaceholder(ratio: PlaceholderRatio, seed: string): string {
+  const bucket = placeholderAssets[ratio];
+  return bucket[hashString(seed) % bucket.length];
+}

--- a/src/hooks/usePlaceholderAssets.ts
+++ b/src/hooks/usePlaceholderAssets.ts
@@ -1,0 +1,53 @@
+import { useSyncExternalStore } from 'react';
+import { pickPlaceholder, type PlaceholderRatio } from '../content/placeholderAssets';
+
+const STORAGE_KEY = 'poised-placeholder-assets';
+
+function readInitial(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+let state = readInitial();
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((listener) => listener());
+}
+
+export function setPlaceholderAssets(on: boolean) {
+  state = on;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, on ? '1' : '0');
+  } catch {
+    // localStorage unavailable — in-memory state still updates for this session
+  }
+  emit();
+}
+
+export function togglePlaceholderAssets() {
+  setPlaceholderAssets(!state);
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+  return state;
+}
+
+export function usePlaceholderAssets() {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
+/** Resolves to a test placeholder (matched by aspect ratio) when the toggle is on, else the real src. */
+export function useTestImage(realSrc: string, ratio: PlaceholderRatio, seed?: string): string {
+  const on = usePlaceholderAssets();
+  return on ? pickPlaceholder(ratio, seed ?? realSrc) : realSrc;
+}

--- a/src/mix1/content.ts
+++ b/src/mix1/content.ts
@@ -43,7 +43,7 @@ export const mix1Work = {
       name: 'Mezo Clay Design System',
       headline: 'Converting design debt into product infrastructure',
       desc: 'Led Mezo design system migration across three product phases (legacy, testnet, mainnet); post-launch audit established 70% component integration and identified systemic overrides from premature styling as the primary implementation bottleneck, informing governance decisions. Managed a direct report and an engineering contributor from execution through deployment. Partnered with the contributing designer to set quality standards and pattern library conventions, building out Uber Base into a React, WCAG 2.2-compliant library purpose-built for the Thesis BitcoinFi suite. Managed, built, and tested 2,000+ variants across 50+ base components, establishing the single source of truth every product surface shipped: the infrastructure behind $322M in testnet deposits, 154K transactions, and $151M TVL at mainnet, peaking at $200M+.',
-      image: '/images/portfolio/mock-thesis-systems.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'systems',
       sector: 'crypto',
     },
@@ -51,7 +51,7 @@ export const mix1Work = {
       name: 'Deposit on Mezo',
       headline: 'Improving the deposit flow that unlocked Mezo’s liquidity',
       desc: 'Depositing Bitcoin to Mezo wasn’t a standard transfer — users were bridging assets across chains into a protocol where a wrong address meant permanent loss of funds. Research confirmed the existing deposit flow was fundamentally broken — perceived as risky and confusing. The redesign introduced upfront deposit instructions, surfaced network context and minimum thresholds before commitment, and provided unambiguous success states so users knew their funds had arrived safely. The deposit flow became the primary on-ramp enabling liquidity for vaults, pools, and rewards — contributing to Mezo’s growth to $200M+ TVL.',
-      image: '/images/portfolio/project-hero-coinbase.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'product',
       sector: 'crypto',
     },
@@ -59,7 +59,7 @@ export const mix1Work = {
       name: 'Borrow MUSD on Mezo',
       headline: 'Making high-stakes borrowing feel safe, not complex',
       desc: 'MUSD borrowing required users to understand collateralization, liquidation risk, and variable APR simultaneously — concepts that had no mainstream equivalent. The design challenge wasn’t simplification for its own sake; it was making consequential financial decisions feel appropriately weighted without overwhelming users into inaction. The redesign introduced progressive disclosure, consolidated error handling to a single inline signal, and leaned on benchmarked design patterns to reduce DeFi complexity for a larger addressable market.',
-      image: '/images/portfolio/project-01-borrow.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'product',
       sector: 'crypto',
     },
@@ -67,7 +67,7 @@ export const mix1Work = {
       name: 'BlockFi Mobile',
       headline: 'Redefining mobile trading to drive 200%+ transaction volume in 90 days',
       desc: 'BlockFi’s mobile trading experience was scoped too narrowly — USD denomination was the surface problem, but the deeper opportunity was rebuilding the entire flow around how users actually trade. As Director, I pushed back on the original brief using product benchmarking and heuristic evaluation, moving buy/sell intent before the amount screen to eliminate a segmented control that was adding cognitive load, making room for surfacing recurring trades earlier in the flow — previously buried at the summary screen. Both decisions were validated through user testing before implementation, and applied consistently across web and mobile. Trades grew 200%+ within 90 days of launch — outpacing web-based trades for the first time — and contributed directly to BlockFi’s growth in service of 225K+ clients.',
-      image: '/images/portfolio/gf-blockfi.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'leadership',
       sector: 'fintech',
     },
@@ -75,7 +75,7 @@ export const mix1Work = {
       name: 'BlockFi — Credit Card Rewards (Mobile)',
       headline: 'Scoping and shipping the mobile experience behind the world’s first Bitcoin rewards credit card',
       desc: 'Performed as lead product designer for the world’s first Bitcoin rewards credit card — building the design system and implementing the native experience against a web version, reusing the same components across both to stave off design debt and create a unified cross-platform experience. Reached 50,000+ active cardholders within 90 days of national launch, spending 450% above the card industry average and pacing toward $2B+ in annualized volume (BlockFi, Oct 2021).',
-      image: '/images/portfolio/gf-blockfi.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'leadership',
       sector: 'fintech',
     },
@@ -83,7 +83,7 @@ export const mix1Work = {
       name: 'C@SH Native App',
       headline: 'Zero-to-one product design that informed a strategic pivot',
       desc: 'At an a16z Crypto portfolio company, I established the design function from zero — customizing Uber Base into a branded component library before a single internal designer was hired, doubling engineering speed and giving the team infrastructure to build with from day one. The VC principal set a high bar: a premium product resonating with an urban audience. We met it — validated through affinity testing — delivering a full light and dark mode experience. The same research surfaced a harder finding: the market hadn’t matured enough for a social wallet. That insight informed a strategic pivot, preserving capital that would otherwise have been burned against a product without sufficient traction.',
-      image: '/images/portfolio/gf-cash.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'leadership',
       sector: 'crypto',
     },
@@ -91,7 +91,7 @@ export const mix1Work = {
       name: 'EASI Food Delivery',
       headline: 'Rearchitecting EASI to win a second audience — and a $500M valuation',
       desc: 'EASI had a strong market position in Australian diaspora communities, but poor usability, frequent crashes, and a sub-3.0 App Store rating were capping their TAM. In six weeks, I used benchmarking to build stakeholder confidence for a full redesign, then rebuilt core ordering flow in parallel with engineering’s re-architecture — prototyping and testing each decision before handoff. App Store rating climbed from below 3.0 to 4.5 stars. EASI surpassed 1M+ users, reached a $500M+ valuation, and was acquired by HungryPanda in 2022 — whose acquisition rationale mirrored the market strategy the redesign was built around.',
-      image: '/images/portfolio/gf-easi.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'consultant',
       sector: 'consumer',
     },
@@ -99,7 +99,7 @@ export const mix1Work = {
       name: 'Krisp AI',
       headline: 'Product innovation for Krisp.ai’s noise cancelling desktop application',
       desc: 'Krisp had built strong utility as a consumer noise-cancellation tool, but the desktop experience hadn’t kept pace with what AI-native software was starting to look like. Engaged as principal design consultant, I redesigned the application around a modern UI system — introducing branded components to accelerate implementation, reduce design debt, and establish a visual foundation capable of scaling with the product. The engagement paused when COVID-19 created market uncertainty across the space. Krisp would later pivot into meeting intelligence and recording — a shift toward enterprise aesthetics and a design brief the original work wasn’t built to serve.',
-      image: '/images/portfolio/gf-krisp.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'consultant',
       sector: 'ai',
     },
@@ -107,7 +107,7 @@ export const mix1Work = {
       name: 'Zalando Stories',
       headline: 'One motion language for a platform built on a proven bet',
       desc: 'Zalando’s majority stake in Highsnobiety had already proven the model — 80+ curated drops reaching 7M+ unique users before the platform had a name. Turning that into a permanent feature meant solving motion first: every editorial format needed transitions that felt consistent across app and web, and motion was still a pile of one-off files. Led a design-sprint week to define a platform-agnostic system — timing and easing as shared tokens, composed into a primitive set (sheet, enter/exit, press, swipe-up) any format could adopt instead of reinventing. Stories launched Sept 14, 2023 across 11 markets with five formats, and has scaled to 500+ stories and 700+ brands since.',
-      image: '/images/portfolio/gf-fennel.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'systems',
       sector: 'consumer',
     },
@@ -121,8 +121,8 @@ export const mix1About = {
   teamIntro: 'Osandi Sekoú Robinson — product & design leader.',
   teamBody:
     'Startup founder turned design executive with 14 years building products and the orgs that ship them — across fintech, crypto, and consumer mobile.',
-  portrait: '/images/osandi-portrait-anime.png',
-  capabilitiesFigure: '/images/portfolio/mock-poised.png',
+  portrait: '/images/placeholder-mix1/ratio-1024x1024.svg',
+  capabilitiesFigure: '/images/placeholder-mix1/ratio-214x290.svg',
   team: [{ name: 'Osandi Sekoú Robinson', role: 'Product & design leader' }],
   capabilities: [
     {
@@ -195,7 +195,7 @@ export const mix1About = {
     {
       name: 'Discover',
       copy: 'Discovery determines whether a team is solving the right problem before anyone commits to a solution. Widen the aperture before narrowing toward anything buildable. The output is alignment on the problem, the evidence needed, and why it matters to the business.',
-      image: '/images/studio/agency-01-9b4387d5aa.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: [
         'Customer feedback',
         'Quant data analysis',
@@ -212,13 +212,13 @@ export const mix1About = {
     {
       name: 'Explore',
       copy: 'With the evidential problem in sight, artifacts and written context align stakeholders — connecting hypotheses and objectives to human needs and business goals.',
-      image: '/images/studio/agency-05-6ff4e85875.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: ['Diagram', 'Journey map', 'Wireframe', 'Prompt design & prototyping'],
     },
     {
       name: 'Validate',
       copy: 'Validation can occur at multiple touchpoints with an array of artifacts, ensuring the work addresses the needs of users — and, inevitably, the business.',
-      image: '/images/studio/agency-06-c2c1790069.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: [
         'Card sorting',
         'Design reviews',
@@ -235,7 +235,7 @@ export const mix1About = {
     {
       name: 'Implement',
       copy: 'Collaborate closely with engineers for design alignment and capture details pre-release. For new components, ensure awareness for product consistency. Cross-functional stakeholders are informed via Loom and case-study briefs before final sign-off — including how we measure design intent.',
-      image: '/images/studio/agency-07-a0986e9d3f.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: [
         'Feasibility sign-off',
         'Compliance sign-off',
@@ -377,7 +377,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Systems',
     readTime: 4,
-    image: '/images/portfolio/mock-thesis-systems.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Converting design debt into product infrastructure',
     intro:
       'What starts as a styling override always becomes a system problem. At Mezo, three product phases — legacy, testnet, mainnet — had accumulated enough inconsistency to slow every team touching the product. The work was infrastructure first, interface second.',
@@ -389,7 +389,7 @@ export const mix1Projects = [
           "Led the full migration to Mezo Clay — partnering with Uber Base as the foundation and building a WCAG 2.2-compliant React library purpose-built for the Thesis BitcoinFi suite. Managed a direct report and an engineering contributor from execution through deployment.",
           "The post-launch audit identified premature styling as the primary implementation bottleneck — a pattern that shows up in every fast-moving crypto team. The fix wasn't more components; it was clearer rules about when to override them.",
         ],
-        images: ['/images/portfolio/mock-thesis-systems.png', '/images/portfolio/mezo-hero.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: '2,000+ variants. 50+ base components. One source of truth.',
@@ -398,7 +398,7 @@ export const mix1Projects = [
           "Partnered with the contributing designer to set quality standards and pattern library conventions. Built and tested every variant against the Mezo product surfaces — deposit, borrow, wallet, explore — so each could ship without a separate design review cycle.",
           "The system became the infrastructure behind $322M in testnet deposits, 154K transactions, and $151M TVL at mainnet, peaking at $200M+.",
         ],
-        images: ['/images/portfolio/mezo-wallet.png', '/images/portfolio/mezo-explore.png', '/images/portfolio/mezo-borrow.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Design debt compounds silently until it stops shipping features.',
@@ -407,14 +407,10 @@ export const mix1Projects = [
           "A 70% component integration rate at post-launch audit sounds like success. It is — but the 30% that wasn't integrated told the real story: premature styling decisions made during testnet were being maintained as one-off overrides instead of being resolved back into the system.",
           "The governance decisions informed by that audit — when to override, when to extend, when to propose a new component — were as important as the components themselves.",
         ],
-        images: ['/images/portfolio/mock-thesis-systems.png', '/images/portfolio/mezo-borrow.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: [
-      '/images/portfolio/mock-thesis-systems.png',
-      '/images/portfolio/mezo-hero.png',
-      '/images/portfolio/mezo-wallet.png',
-    ],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'Infrastructure that outlasts the sprint cycle is the difference between a design system and a component dump.',
     stats: [
       { name: 'Component integration', description: 'Post-launch audit established the baseline for system governance decisions.', value: '70%' },
@@ -447,7 +443,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Product',
     readTime: 3,
-    image: '/images/portfolio/project-hero-coinbase.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: "Improving the deposit flow that unlocked Mezo's liquidity",
     intro:
       "Depositing Bitcoin to Mezo wasn't a standard transfer. Users were bridging assets across chains into a protocol where a wrong address meant permanent loss of funds. The bar for clarity wasn't high — it was non-negotiable.",
@@ -459,7 +455,7 @@ export const mix1Projects = [
           "The existing deposit flow was perceived as risky and confusing — no upfront context, no network guidance, no unambiguous success state. Users had to infer what was happening at every step.",
           "The redesign introduced upfront deposit instructions before any commitment, surfaced network context and minimum thresholds early, and delivered success states specific enough that users knew their funds had arrived safely — not just that a transaction had fired.",
         ],
-        images: ['/images/portfolio/project-hero-coinbase.png', '/images/portfolio/project-after-coinbase.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'The deposit flow became the primary on-ramp for all of Mezo\'s liquidity.',
@@ -468,10 +464,10 @@ export const mix1Projects = [
           "Vaults, pools, and rewards all depended on a working deposit experience. The redesign unblocked each of them — contributing directly to Mezo's growth to $200M+ TVL.",
           "Sprint completion held at 98% across the engagement, which meant the research and design process ran fast enough to stay ahead of engineering.",
         ],
-        images: ['/images/portfolio/mezo-hero.png', '/images/portfolio/mezo-explore.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/project-hero-coinbase.png', '/images/portfolio/project-after-coinbase.png', '/images/portfolio/mezo-hero.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'Clarity at the point of commitment is not a UX nicety in a protocol where a wrong address means permanent loss.',
     stats: [
       { name: 'TVL at mainnet', description: 'Deposit flow was the primary on-ramp for all Mezo liquidity growth.', value: '$200M+' },
@@ -502,7 +498,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Product',
     readTime: 3,
-    image: '/images/portfolio/project-01-borrow.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Making high-stakes borrowing feel safe, not complex',
     intro:
       'MUSD borrowing required users to hold collateralization ratio, liquidation threshold, and variable APR in their heads simultaneously. None of those concepts have mainstream equivalents. The design problem was weight, not simplification.',
@@ -514,7 +510,7 @@ export const mix1Projects = [
           "Progressive disclosure let us surface complexity only when it was relevant to the decision at hand. A user setting their collateral ratio doesn't need to see APR mechanics at the same moment.",
           "Error handling was consolidated to a single inline signal. Before the redesign, errors appeared in multiple places with inconsistent framing — adding cognitive load at the worst possible moment.",
         ],
-        images: ['/images/portfolio/project-01-borrow.png', '/images/portfolio/project-02-loan.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Benchmarking against established DeFi patterns reduced the learning curve.',
@@ -523,10 +519,10 @@ export const mix1Projects = [
           "The redesign borrowed interaction models from familiar financial interfaces — not to hide the complexity of DeFi, but to lower the entry cost for users coming from traditional finance.",
           "The borrow flow shipped as part of the mainnet launch suite, contributing to Mezo's $200M+ TVL and supporting expansion into a broader addressable market beyond early adopters.",
         ],
-        images: ['/images/portfolio/project-03-wallet.png', '/images/portfolio/project-04-marketplace.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/project-01-borrow.png', '/images/portfolio/project-02-loan.png', '/images/portfolio/project-03-wallet.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'The job isn\'t to make DeFi simple. It\'s to make consequential decisions feel proportionally weighted.',
     stats: [
       { name: 'TVL at mainnet', description: 'Borrow flow contributed to Mezo\'s liquidity growth alongside deposit and wallet.', value: '$200M+' },
@@ -556,7 +552,7 @@ export const mix1Projects = [
     year: '2021',
     service: 'Leadership',
     readTime: 4,
-    image: '/images/portfolio/gf-blockfi.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Redefining mobile trading to drive 200%+ transaction volume in 90 days',
     intro:
       "BlockFi's mobile trading had a surface problem and a structural one. USD denomination was the thing people complained about. The real issue was a flow built around what engineering found easiest to implement, not how traders actually think.",
@@ -568,7 +564,7 @@ export const mix1Projects = [
           "Product benchmarking and heuristic evaluation surfaced a pattern no one had named yet: the segmented control forcing users to choose denomination before intent was the single biggest source of drop-off. Moving buy/sell intent before the amount screen eliminated it.",
           "Recurring trades had been buried at the summary screen — three steps too late. Surfacing them earlier required a structural change to the flow that the original brief hadn't scoped. Both decisions were validated through user testing before implementation.",
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/mock-bbu.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Trades grew 200%+ in 90 days. Mobile outpaced web for the first time.',
@@ -577,10 +573,10 @@ export const mix1Projects = [
           "The same changes were applied consistently across web and mobile — not as a one-off mobile fix but as a rethought trading interaction model. The consistency mattered as much as the individual improvements.",
           "The result contributed directly to BlockFi's growth in service of 225K+ clients and $50M monthly revenue — and validated the case for design having a seat at product strategy decisions, not just execution.",
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/gf-fennel.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/mock-bbu.png', '/images/portfolio/gf-fennel.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'The brief was too small. Pushing back on it was the design work.',
     stats: [
       { name: 'Trades in 90 days', description: 'Mobile outpaced web-based trades for the first time following launch.', value: '+200%' },
@@ -616,11 +612,11 @@ export const mix1Projects = [
     year: '2021',
     service: 'Leadership',
     readTime: 4,
-    image: '/images/portfolio/gf-blockfi.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     // Placeholder frames, framed at the iPhone 17 Pro Max's screen ratio (1320x2868)
     // pending real card screens — swap each src once sourced (see TODO above). Rendered
     // as a body carousel (see ProjectPage.tsx), not in the hero.
-    screenCarousel: Array.from({ length: 12 }, () => '/images/portfolio/gf-blockfi.jpg'),
+    screenCarousel: Array.from({ length: 12 }, () => '/images/placeholder-mix1/ratio-1320x2868.svg'),
     headline: 'Scoping and shipping the mobile experience behind the world’s first Bitcoin rewards credit card',
     intro:
       "BlockFi's Bitcoin Rewards Visa card wasn't a marketing bet — it was a product bet on a category no issuer had shipped: a credit card that paid rewards in Bitcoin instead of points or cashback. Before launch it had already pulled a waitlist of roughly 400,000 signups (Dec 2020–Jul 2021), which meant the mobile experience — enrollment, card management, and rewards tracking — had to hold up under real demand from day one, not iterate its way there.",
@@ -632,7 +628,7 @@ export const mix1Projects = [
           'Lead designer, mobile, for the BlockFi Rewards Card experience. The card launched nationally in mid-2021 on the Visa network, issued by Evolve Bank & Trust and powered by Deserve’s card platform, converting a ~400K-signup waitlist into an active cardholder base.',
           'Built the design system and implemented the native experience against a web version — the same components reused across both platforms rather than diverging.',
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: '50,000+ active cardholders within 90 days of national launch, spending 450% above the card industry average and pacing toward $2B+ in annualized volume.',
@@ -641,10 +637,10 @@ export const mix1Projects = [
           'By December 2021, cardholders had grown past 70,000 — a secondary source (Shorty Awards), cited with lighter confidence than BlockFi’s own release above. Rewards distribution reached 120+ BTC (~$6.8M) as of October 12, 2021 (BlockFi, GlobeNewswire).',
           'That reuse staved off design debt and created a unified cross-platform experience — one system driving both native and web, not two drifting apart.',
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-blockfi.jpg'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead:
       '“Crypto rewards programs are a compelling way to engage consumers in the crypto economy. We’re excited to see programs like the BlockFi Rewards Visa Card, which offer rewards that are relevant to the growing community of digital currency adopters.” — Forbes, Jul 6 2021',
     stats: [
@@ -679,7 +675,7 @@ export const mix1Projects = [
     year: '2022',
     service: 'Leadership',
     readTime: 3,
-    image: '/images/portfolio/gf-cash.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Zero-to-one product design that informed a strategic pivot',
     intro:
       "Building a design function before the first hire means every decision compounds. The component library you build becomes the product. The research you run becomes the strategy.",
@@ -691,7 +687,7 @@ export const mix1Projects = [
           "Customized Uber Base into a branded library that doubled engineering speed and gave the team a shared vocabulary to build with from day one. The VC principal set a high bar — a premium product resonating with an urban audience — and we met it, validated through affinity testing.",
           "Full light and dark mode shipped. The same research surfaced a harder finding: the market hadn't matured enough for a social wallet.",
         ],
-        images: ['/images/portfolio/gf-cash.png', '/images/portfolio/mock-vinyl-crate.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: "The research that shaped the pivot preserved capital that would otherwise have been spent.",
@@ -700,10 +696,10 @@ export const mix1Projects = [
           "Identifying insufficient market traction before over-investing in the product direction was the most valuable output of the engagement. The design foundation remained intact for the company's next direction.",
           "Building 0→1 means the research has to do double duty — validating the product and validating the strategy. Here, it did both.",
         ],
-        images: ['/images/portfolio/mock-a16z.png', '/images/portfolio/gf-cash.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-cash.png', '/images/portfolio/mock-a16z.png', '/images/portfolio/mock-vinyl-crate.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'The most valuable deliverable was the research that stopped us from building the wrong thing.',
     stats: [
       { name: 'Design function', description: 'Built from zero before the first internal design hire.', value: '0 → 1' },
@@ -733,7 +729,7 @@ export const mix1Projects = [
     year: '2020',
     service: 'Consultant',
     readTime: 4,
-    image: '/images/portfolio/gf-easi.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Rearchitecting EASI to win a second audience — and a $500M valuation',
     intro:
       "EASI had a real market and a broken product. A sub-3.0 App Store rating and frequent crashes weren't edge cases — they were capping the total addressable market. The problem wasn't the audience; it was the experience they were being asked to tolerate.",
@@ -745,7 +741,7 @@ export const mix1Projects = [
           "Six weeks. Skeptical stakeholders. A team that had shipped the original product and wasn't sure anything needed to change. Benchmarking gave us a shared language for what 'good' looked like — not opinions, but patterns from products the team already respected.",
           "Once the case was made, the redesign ran in parallel with engineering's re-architecture — prototyping and testing each decision before handoff, so no one was waiting on anyone.",
         ],
-        images: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/mock-ubiquiti.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'App Store rating: below 3.0 to 4.5. Acquired for $500M+.',
@@ -754,10 +750,10 @@ export const mix1Projects = [
           "EASI surpassed 1M+ users and reached a $500M+ valuation. HungryPanda's acquisition rationale in 2022 mirrored the market strategy the redesign was built around — expanding from diaspora communities into a broader urban audience.",
           "The six-week timeline wasn't a constraint. It was the discipline that kept the scope focused on what would move the numbers.",
         ],
-        images: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/gf-blinkist.jpg'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/gf-blinkist.jpg', '/images/portfolio/mock-ubiquiti.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'A 4.5-star rating is a market signal. The $500M acquisition validated the strategy the redesign was built around.',
     stats: [
       { name: 'App Store rating', description: 'Climbed from below 3.0 to 4.5 stars following the redesign launch.', value: '3.0→4.5' },
@@ -788,7 +784,7 @@ export const mix1Projects = [
     year: '2020',
     service: 'Consultant',
     readTime: 3,
-    image: '/images/portfolio/gf-krisp.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: "Product innovation for Krisp.ai's noise cancelling desktop application",
     intro:
       "Krisp had strong utility and a dated interface. The noise cancellation worked. The desktop experience hadn't kept pace with what AI-native software was starting to look like — and that gap was starting to matter.",
@@ -800,7 +796,7 @@ export const mix1Projects = [
           "Engaged as principal design consultant, I redesigned the application around a cohesive UI system — introducing branded components to accelerate implementation, reduce design debt, and establish a visual foundation capable of scaling with the product.",
           "The work ran until COVID-19 created market uncertainty across the consumer audio space. What was scoped as a foundation for growth became a foundation for a pivot.",
         ],
-        images: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-early-flow.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Krisp pivoted into meeting intelligence. The structural work held.',
@@ -809,10 +805,10 @@ export const mix1Projects = [
           "The shift toward enterprise aesthetics and recording features was a different design brief than the original work was built to serve. But the component layer and the system thinking behind it gave the team a structured starting point for that evolution.",
           "That's the value of system work over surface work — it outlives the original brief.",
         ],
-        images: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-apple-genius.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-early-flow.png', '/images/portfolio/mock-apple-genius.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'System work outlives the brief it was built for. That\'s the difference between components and infrastructure.',
     stats: [
       { name: 'Engagement type', description: 'Engaged as principal design consultant for the desktop UI system redesign.', value: 'Principal' },
@@ -840,7 +836,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Systems',
     readTime: 4,
-    image: '/images/portfolio/gf-fennel.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'One motion language for a platform built on a proven bet',
     intro:
       "In 2022, Zalando took a majority stake in Highsnobiety, betting that editorial content — not just catalog browsing — could drive commerce at scale. The bet was already working: over 80 curated product drops run together had reached 7 million+ unique users before the platform even had a name. Stories was the next step — turning that into a permanent feature, not a one-off collaboration.",
@@ -852,7 +848,7 @@ export const mix1Projects = [
           'Getting there meant solving a less glamorous problem first. Every editorial format — a cover story, a style guide, a guest edit — needed transitions that felt consistent whether someone hit them on the app or the web. Motion was still a pile of individual files; the same gesture read differently depending on where you encountered it.',
           'An eight-step sprint opened by naming that fragmentation, then mapped every existing motion instance across the product before setting a bar for what a shared system would need to cover.',
         ],
-        images: ['/images/portfolio/project-02-loan.png', '/images/portfolio/project-03-wallet.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Timing tokens, then a short list of primitives that compose into any format.',
@@ -861,10 +857,10 @@ export const mix1Projects = [
           'What shipped: tokens defining raw timing and easing, primitives — sheet, enter/exit, press, swipe-up — defining reusable interaction patterns built from those tokens, and patterns combining primitives into on-screen behaviors editors and engineers could reach for without re-deriving anything. Swipe-up, the gesture that opens a Story full-screen, became the reference example: specified once, used everywhere a story needed to expand.',
           'Design and engineering stopped trading animation files. A new format now borrows motion from the token layer instead of inventing its own.',
         ],
-        images: ['/images/portfolio/project-04-marketplace.png', '/images/portfolio/project-after-coinbase.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-fennel.png', '/images/portfolio/project-02-loan.png', '/images/portfolio/project-04-marketplace.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'Stories launched September 14, 2023, across 11 European markets with five recurring formats. The motion system is what let that scale to 500+ stories and 700+ brands without the consistency breaking — the difference between a one-off content experiment and a durable platform.',
     stats: [
       { name: 'Pre-launch reach', description: '80+ curated product drops with Highsnobiety, before Stories had a name.', value: '7M+ users' },

--- a/src/sections/home/FeaturedArchive.tsx
+++ b/src/sections/home/FeaturedArchive.tsx
@@ -6,6 +6,20 @@ import { featured } from '../../content/archive';
 import { POISED_BASE } from '../../content/site';
 import { Eyebrow, MediaFrame, TextLink, Title } from '../../components/primitives';
 import { usePrefersReducedMotion } from '../../hooks/usePrefersReducedMotion';
+import { useTestImage } from '../../hooks/usePlaceholderAssets';
+
+function FeaturedCard({ item }: { item: (typeof featured)[number] }) {
+  const src = useTestImage(item.image, '4:5', item.frame);
+  return (
+    <Link to={`${POISED_BASE}/work`} className="featured-card">
+      <MediaFrame src={src} alt={item.name} />
+      <div className="featured-data">
+        <span className="featured-name">{item.name}</span>
+        <span className="mono">{item.frame}</span>
+      </div>
+    </Link>
+  );
+}
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -55,13 +69,7 @@ export function FeaturedArchive() {
         <div className="featured-viewport">
           <div ref={trackRef} className="featured-track">
             {featured.map((item) => (
-              <Link key={item.frame} to={`${POISED_BASE}/work`} className="featured-card">
-                <MediaFrame src={item.image} alt={item.name} />
-                <div className="featured-data">
-                  <span className="featured-name">{item.name}</span>
-                  <span className="mono">{item.frame}</span>
-                </div>
-              </Link>
+              <FeaturedCard key={item.frame} item={item} />
             ))}
             <div className="featured-end">
               <span className="mono">END OF SELECTION</span>

--- a/src/sections/home/RollShowcase.tsx
+++ b/src/sections/home/RollShowcase.tsx
@@ -2,6 +2,29 @@ import { useState } from 'react';
 import { roll } from '../../content/home';
 import { Eyebrow, MonoText, Title } from '../../components/primitives';
 import { useInView } from '../../hooks/useInView';
+import { useTestImage } from '../../hooks/usePlaceholderAssets';
+
+function AngleThumb({
+  src,
+  no,
+  label,
+  active,
+  onClick,
+}: {
+  src: string;
+  no: string;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const thumbSrc = useTestImage(src, 'square', no);
+  return (
+    <button type="button" className={`angle-thumb${active ? ' is-active' : ''}`} onClick={onClick} aria-label={label}>
+      <img src={thumbSrc} alt="" />
+      <span className="angle-no">{no}</span>
+    </button>
+  );
+}
 
 export function RollShowcase() {
   const [stage, setStage] = useState<string>(roll.stage);
@@ -37,26 +60,22 @@ export function RollShowcase() {
 
         <div className="roll-thumbs" role="group" aria-label="Angles">
           <MonoText className="mono">ANGLES</MonoText>
-          <button
-            type="button"
-            className={`angle-thumb${stage === roll.stage ? ' is-active' : ''}`}
+          <AngleThumb
+            src={roll.stage}
+            no="01"
+            label="View main frame"
+            active={stage === roll.stage}
             onClick={() => setStage(roll.stage)}
-            aria-label="View main frame"
-          >
-            <img src={roll.stage} alt="" />
-            <span className="angle-no">01</span>
-          </button>
+          />
           {roll.angles.map((angle) => (
-            <button
+            <AngleThumb
               key={angle.no}
-              type="button"
-              className={`angle-thumb${stage === angle.image ? ' is-active' : ''}`}
+              src={angle.image}
+              no={angle.no}
+              label={`View alternate angle ${angle.no}`}
+              active={stage === angle.image}
               onClick={() => setStage(angle.image)}
-              aria-label={`View alternate angle ${angle.no}`}
-            >
-              <img src={angle.image} alt="" />
-              <span className="angle-no">{angle.no}</span>
-            </button>
+            />
           ))}
         </div>
       </div>

--- a/src/sections/project/BeforeAfter.tsx
+++ b/src/sections/project/BeforeAfter.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { project } from '../../content/project';
 import { Eyebrow, MonoText, Title } from '../../components/primitives';
+import { useTestImage } from '../../hooks/usePlaceholderAssets';
 
 const clamp = (v: number) => Math.min(92, Math.max(8, v));
 
@@ -8,6 +9,8 @@ export function BeforeAfter() {
   const [pos, setPos] = useState(50);
   const stageRef = useRef<HTMLDivElement>(null);
   const { beforeAfter: ba } = project;
+  const beforeSrc = useTestImage(ba.beforeImage, '16:9', 'before');
+  const afterSrc = useTestImage(ba.afterImage, '16:9', 'after');
 
   const fromPointer = (clientX: number) => {
     const rect = stageRef.current!.getBoundingClientRect();
@@ -33,8 +36,8 @@ export function BeforeAfter() {
           if (e.buttons > 0) fromPointer(e.clientX);
         }}
       >
-        <img className="ba-before" src={ba.beforeImage} alt={ba.beforeLabel} />
-        <img className="ba-after" src={ba.afterImage} alt={ba.afterLabel} />
+        <img className="ba-before" src={beforeSrc} alt={ba.beforeLabel} />
+        <img className="ba-after" src={afterSrc} alt={ba.afterLabel} />
         <div className="ba-divider" aria-hidden />
         <button
           type="button"

--- a/src/sections/project/ProjectSections.tsx
+++ b/src/sections/project/ProjectSections.tsx
@@ -3,6 +3,7 @@ import { project } from '../../content/project';
 import { Eyebrow, MediaFrame, MonoText, Quote, Title } from '../../components/primitives';
 import { Lightbox } from '../../components/overlays/Lightbox';
 import { useInView } from '../../hooks/useInView';
+import { useTestImage } from '../../hooks/usePlaceholderAssets';
 import './project.css';
 
 export function ProjectOpen() {
@@ -52,9 +53,10 @@ export function ProjectBrief() {
 
 export function ProjectStillOne() {
   const { stillOne } = project;
+  const src = useTestImage(stillOne.image, '16:10', 'still-one');
   return (
     <section className="p-still" aria-label={stillOne.caption}>
-      <MediaFrame src={stillOne.image} alt={stillOne.caption} />
+      <MediaFrame src={src} alt={stillOne.caption} />
       <div className="p-cap">
         <MonoText>{stillOne.caption}</MonoText>
         <MonoText>{stillOne.index}</MonoText>
@@ -63,13 +65,18 @@ export function ProjectStillOne() {
   );
 }
 
+function TwoUpImage({ img }: { img: (typeof project.twoUp.images)[number] }) {
+  const src = useTestImage(img.src, '4:5');
+  return <MediaFrame src={src} alt={img.alt} />;
+}
+
 export function ProjectTwoUp() {
   const { twoUp } = project;
   return (
     <section className="p-still" aria-label={twoUp.caption}>
       <div className="p-still--two">
         {twoUp.images.map((img) => (
-          <MediaFrame key={img.src} src={img.src} alt={img.alt} />
+          <TwoUpImage key={img.src} img={img} />
         ))}
       </div>
       <div className="p-cap">
@@ -82,14 +89,36 @@ export function ProjectTwoUp() {
 
 export function ProjectStillTwo() {
   const { stillTwo } = project;
+  const src = useTestImage(stillTwo.image, '16:10', 'still-two');
   return (
     <section className="p-still" aria-label={stillTwo.caption}>
-      <MediaFrame src={stillTwo.image} alt={stillTwo.caption} />
+      <MediaFrame src={src} alt={stillTwo.caption} />
       <div className="p-cap">
         <MonoText>{stillTwo.caption}</MonoText>
         <MonoText>{stillTwo.index}</MonoText>
       </div>
     </section>
+  );
+}
+
+function SheetThumb({
+  frame,
+  onOpen,
+}: {
+  frame: { frame: string; image: string };
+  onOpen: (frame: { frame: string; image: string }) => void;
+}) {
+  const src = useTestImage(frame.image, 'square', frame.frame);
+  return (
+    <button
+      type="button"
+      className="sheet-thumb"
+      onClick={() => onOpen({ frame: frame.frame, image: src })}
+      aria-label={`Enlarge ${frame.frame}`}
+    >
+      <img src={src} alt={frame.frame} loading="lazy" />
+      <span className="mono">{frame.frame}</span>
+    </button>
   );
 }
 
@@ -111,16 +140,7 @@ export function ContactSheet() {
 
       <div className="sheet-grid">
         {sheet.frames.map((frame) => (
-          <button
-            key={frame.frame}
-            type="button"
-            className="sheet-thumb"
-            onClick={() => setOpenFrame(frame)}
-            aria-label={`Enlarge ${frame.frame}`}
-          >
-            <img src={frame.image} alt={frame.frame} loading="lazy" />
-            <span className="mono">{frame.frame}</span>
-          </button>
+          <SheetThumb key={frame.frame} frame={frame} onOpen={setOpenFrame} />
         ))}
       </div>
 

--- a/src/sections/work/WorkArchive.tsx
+++ b/src/sections/work/WorkArchive.tsx
@@ -1,12 +1,25 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { archive, type Category } from '../../content/archive';
+import { archive, type ArchiveFrame, type Category } from '../../content/archive';
 import { POISED_BASE } from '../../content/site';
 import { Chip, Eyebrow, MediaFrame, MonoText, Title } from '../../components/primitives';
+import { useTestImage } from '../../hooks/usePlaceholderAssets';
 import './work.css';
 
 const CATEGORIES: Category[] = ['Leadership', 'Product', 'Systems', 'Research'];
 type View = 'grid' | 'ledger';
+
+function WorkCard({ frame }: { frame: ArchiveFrame }) {
+  const src = useTestImage(frame.image, '4:5', frame.frame);
+  return (
+    <Link to={`${POISED_BASE}/project`} className="work-card">
+      <MediaFrame src={src} alt={frame.name} />
+      <div className="work-card-meta">
+        <span className="work-card-name">{frame.name}</span>
+      </div>
+    </Link>
+  );
+}
 
 export function WorkArchive() {
   const [filter, setFilter] = useState<Category | 'All'>('All');
@@ -58,12 +71,7 @@ export function WorkArchive() {
       {view === 'grid' ? (
         <section key={`${filter}-grid`} className="work-grid" aria-label="Archive grid">
           {frames.map((frame) => (
-            <Link key={frame.frame} to={`${POISED_BASE}/project`} className="work-card">
-              <MediaFrame src={frame.image} alt={frame.name} />
-              <div className="work-card-meta">
-                <span className="work-card-name">{frame.name}</span>
-              </div>
-            </Link>
+            <WorkCard key={frame.frame} frame={frame} />
           ))}
         </section>
       ) : (


### PR DESCRIPTION
## Summary
- Matches the 14 test images from #62 to the site's image slots by aspect ratio (`4:5`, `16:10`, `16:9`, `square`) and gates them behind a persistent "TEST ASSETS" toggle in the site chrome — real content stays untouched by default.
- Slots with no close ratio match (hero backdrop cells, roll-showcase main stage, about/dev portraits at 3:4/4:3) are left on real content rather than force-cropping a mismatched placeholder in.
- The actual issue attachments couldn't be pulled through this environment's GitHub proxy, so `public/images/placeholder/` currently holds labeled SVG stand-ins at the exact source pixel dimensions from #62. Dropping real files in at the same 14 paths (and updating the extension in `src/content/placeholderAssets.ts`) swaps them in with no other code changes.
- Closes #64: swaps every real image reference in `src/mix1/content.ts` for a labeled placeholder SVG at the same aspect ratio, so no real case-study screenshots ship on `/mix1/*` regardless of the media-blocks toggle's state (that toggle only visually masks images via CSS — it never stops the real files from being fetched). Verified against each container's actual computed aspect ratio (including the one intrinsic-sized slot, the About portrait, matched pixel-for-pixel to the real image's own dimensions) so every grid, carousel, and figure renders at its exact current size. Copy is untouched.

## Test plan
- [x] `npm run build` (tsc -b && vite build) — clean, no type errors
- [x] `npm run lint` (oxlint) — no new warnings in changed files
- [x] Headless-browser walkthrough of `/poised1`, `/poised1/work`, `/poised1/project` with the toggle on/off — verified all four ratio groups (Home archive cards, Work grid, Project stills/two-up, before/after compare, roll-showcase thumbs, contact-sheet + lightbox) render the matched placeholder and the toggle persists via localStorage
- [x] Headless-browser walkthrough of `/mix1/work`, `/mix1/work/:slug` (all project types incl. the screen-carousel variant), `/mix1/about` — confirmed computed `getBoundingClientRect()`/`aspectRatio` for every image container matches pre-change values exactly, no layout drift

https://claude.ai/code/session_0154mQeGMgcXZVZXVsMM4QLK
