### PR TITLE
Update About page team section copy

### DIFF
--- a/src/mix1/content.ts
+++ b/src/mix1/content.ts
@@ -120,7 +120,7 @@ export const mix1About = {
     'I build the conditions for great product work — org infrastructure, delivery systems, and cross-functional standards that make design a measurable driver of business outcomes across 0→1 builds and iterative product evolution.',
   teamIntro: 'Osandi Sekoú Robinson — product & design leader.',
   teamBody:
-    'Startup founder turned design executive with 14 years building products and the orgs that ship them — across fintech, crypto, and consumer mobile.',
+    'I am product fanatic, music producer, entrepreneur, leader and perpetual student. My passion is in generating disruptive product/service ideas with extraordinary uses of technology while delivering products that find a place in the hearts of those who use them.',
   portrait: '/images/osandi-portrait-anime.png',
   capabilitiesFigure: '/images/portfolio/mock-poised.png',
   team: [{ name: 'Osandi Sekoú Robinson', role: 'Product & design leader' }],

--- a/src/mix1/pages/AboutPage.tsx
+++ b/src/mix1/pages/AboutPage.tsx
@@ -39,7 +39,7 @@ export function AboutPage() {
       <section className="team">
         <div className="team__inner">
           <header className="team__header">
-            <h2 className="heading heading--xl">Team</h2>
+            <h2 className="heading heading--xl">Hi</h2>
           </header>
           <p className="team__intro">{mix1About.teamIntro}</p>
           <div className="team__description">


### PR DESCRIPTION
## Summary

- Replace the "Team" heading with "Hi" on the About page
- Replace the team bio paragraph with updated personal copy

## Test plan

- [x] `npm run build` passes clean
- [x] Verified via headless browser: heading renders "Hi", bio paragraph renders the new copy


---
_Generated by [Claude Code](https://claude.ai/code/session_01BMEUxLAyt73gZPyp4LWUWg)_