### PR TITLE
Update Selected companies list and remove Zalando Stories

### DIFF
--- a/src/mix1/content.ts
+++ b/src/mix1/content.ts
@@ -250,7 +250,7 @@ export const mix1About = {
       ],
     },
   ],
-  clients: ['Apple', 'Square', 'BlockFi', 'Andreessen Horowitz', 'Thesis*', 'Mezo', 'EASI', 'Fennel', 'Krisp.ai', 'Vinyl Crate'],
+  clients: ['Apple', 'Square', 'BlockFi', 'Andreessen Horowitz', 'Thesis*', 'EASI', 'Fennel', 'Krisp.ai', 'Vinyl Crate', 'Layer', 'Direct TV', 'Territory Foods', 'VNYLST'],
   seeking: 'Seeking design leadership roles where product, design, and engineering judgment equally matter.',
   contactLine: 'Got questions? Get in touch.',
 } as const;

--- a/src/mix1/content.ts
+++ b/src/mix1/content.ts
@@ -103,14 +103,6 @@ export const mix1Work = {
       service: 'consultant',
       sector: 'ai',
     },
-    {
-      name: 'Zalando Stories',
-      headline: 'One motion language for a platform built on a proven bet',
-      desc: 'Zalando’s majority stake in Highsnobiety had already proven the model — 80+ curated drops reaching 7M+ unique users before the platform had a name. Turning that into a permanent feature meant solving motion first: every editorial format needed transitions that felt consistent across app and web, and motion was still a pile of one-off files. Led a design-sprint week to define a platform-agnostic system — timing and easing as shared tokens, composed into a primitive set (sheet, enter/exit, press, swipe-up) any format could adopt instead of reinventing. Stories launched Sept 14, 2023 across 11 markets with five formats, and has scaled to 500+ stories and 700+ brands since.',
-      image: '/images/portfolio/gf-fennel.png',
-      service: 'systems',
-      sector: 'consumer',
-    },
   ],
 } as const;
 
@@ -437,7 +429,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'Mezo / Thesis' },
       { role: 'PM', name: 'Thesis product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     slug: 'deposit-on-mezo',
@@ -492,7 +484,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'Mezo / Thesis' },
       { role: 'PM', name: 'Thesis product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     slug: 'borrow-musd',
@@ -546,7 +538,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'Mezo / Thesis' },
       { role: 'PM', name: 'Thesis product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     slug: 'blockfi-mobile',
@@ -602,7 +594,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'BlockFi' },
       { role: 'PM', name: 'BlockFi product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     // TODO: gf-blockfi.jpg is a placeholder — same generic hero image already used by
@@ -669,7 +661,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'BlockFi' },
       { role: 'PM', name: 'BlockFi product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     slug: 'cash-native-app',
@@ -723,7 +715,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'a16z Crypto portfolio' },
       { role: 'PM', name: 'C@SH product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     slug: 'easi-food-delivery',
@@ -778,7 +770,7 @@ export const mix1Projects = [
       { role: 'Client', name: 'EASI' },
       { role: 'PM', name: 'EASI product team' },
     ],
-    motionDemos: [],
+    motionDemos: [] as { label: string; src: string }[],
   },
   {
     slug: 'krisp-ai',
@@ -830,65 +822,6 @@ export const mix1Projects = [
       { role: 'Client', name: 'Krisp' },
       { role: 'PM', name: 'Krisp product team' },
     ],
-    motionDemos: [],
-  },
-  {
-    slug: 'zalando-stories',
-    name: 'Zalando Stories',
-    client: 'Zalando',
-    sector: 'Consumer',
-    year: '2023',
-    service: 'Systems',
-    readTime: 4,
-    image: '/images/portfolio/gf-fennel.png',
-    headline: 'One motion language for a platform built on a proven bet',
-    intro:
-      "In 2022, Zalando took a majority stake in Highsnobiety, betting that editorial content — not just catalog browsing — could drive commerce at scale. The bet was already working: over 80 curated product drops run together had reached 7 million+ unique users before the platform even had a name. Stories was the next step — turning that into a permanent feature, not a one-off collaboration.",
-    featuredSections: [
-      {
-        lead: 'The same gesture felt different depending on where you saw it.',
-        richTitle: 'Naming the fragmentation',
-        body: [
-          'Getting there meant solving a less glamorous problem first. Every editorial format — a cover story, a style guide, a guest edit — needed transitions that felt consistent whether someone hit them on the app or the web. Motion was still a pile of individual files; the same gesture read differently depending on where you encountered it.',
-          'An eight-step sprint opened by naming that fragmentation, then mapped every existing motion instance across the product before setting a bar for what a shared system would need to cover.',
-        ],
-        images: ['/images/portfolio/project-02-loan.png', '/images/portfolio/project-03-wallet.png'],
-      },
-      {
-        lead: 'Timing tokens, then a short list of primitives that compose into any format.',
-        richTitle: 'Tokens, primitives, patterns',
-        body: [
-          'What shipped: tokens defining raw timing and easing, primitives — sheet, enter/exit, press, swipe-up — defining reusable interaction patterns built from those tokens, and patterns combining primitives into on-screen behaviors editors and engineers could reach for without re-deriving anything. Swipe-up, the gesture that opens a Story full-screen, became the reference example: specified once, used everywhere a story needed to expand.',
-          'Design and engineering stopped trading animation files. A new format now borrows motion from the token layer instead of inventing its own.',
-        ],
-        images: ['/images/portfolio/project-04-marketplace.png', '/images/portfolio/project-after-coinbase.png'],
-      },
-    ],
-    mockups: ['/images/portfolio/gf-fennel.png', '/images/portfolio/project-02-loan.png', '/images/portfolio/project-04-marketplace.png'],
-    closingLead: 'Stories launched September 14, 2023, across 11 European markets with five recurring formats. The motion system is what let that scale to 500+ stories and 700+ brands without the consistency breaking — the difference between a one-off content experiment and a durable platform.',
-    stats: [
-      { name: 'Pre-launch reach', description: '80+ curated product drops with Highsnobiety, before Stories had a name.', value: '7M+ users' },
-      { name: 'Launch markets', description: 'Austria, Belgium, Denmark, France, Germany, Italy, Netherlands, Spain, Sweden, Switzerland, UK — Sept 14, 2023.', value: '11' },
-      { name: 'Formats at launch', description: 'Cover Story, Style Bible, Guest Edit, The Perfect X, Unpacked.', value: '5' },
-      { name: 'Scaled to', description: 'Stories published since launch, per Zalando.', value: '500+' },
-    ],
-    tech: [
-      { k: 'Method', v: 'Design Sprint · token-first system design' },
-      { k: 'Deliverable', v: 'Timing tokens, motion primitives, DS contribution' },
-      { k: 'Source', v: 'corporate.zalando.com, Sept 14 2023' },
-    ],
-    tags: ['Systems', 'Consumer', 'Motion', 'Design Sprint'],
-    credits: [
-      { role: 'Design lead', name: 'Osandi Robinson' },
-      { role: 'Content', name: 'Mal Som' },
-    ],
-    clientCredits: [
-      { role: 'Client', name: 'Zalando' },
-    ],
-    motionDemos: [
-      { label: 'Default ease', src: '/videos/motion/easing-default.mp4' },
-      { label: 'Ease-out cubic', src: '/videos/motion/easing-out-cubic.mp4' },
-      { label: 'Linear', src: '/videos/motion/easing-linear.mp4' },
-    ],
+    motionDemos: [] as { label: string; src: string }[],
   },
 ] as const;

--- a/src/mix1/markup/home.html
+++ b/src/mix1/markup/home.html
@@ -49,7 +49,6 @@
       <a class="slide cs" href="/work/cash-native-app"><div class="csm"><img src="/images/portfolio/gf-cash.png" alt="C@SH Native App" loading="lazy"/></div><p class="t">C@SH</p><p class="d">Zero-to-one at a16z Crypto that informed a strategic pivot.</p></a>
       <a class="slide cs" href="/work/easi-food-delivery"><div class="csm"><img src="/images/portfolio/gf-easi.jpg" alt="EASI Food Delivery" loading="lazy"/></div><p class="t">EASI</p><p class="d">Rearchitecting to win a second audience — $500M valuation, acquired.</p></a>
       <a class="slide cs" href="/work/krisp-ai"><div class="csm"><img src="/images/portfolio/gf-krisp.jpg" alt="Krisp AI" loading="lazy"/></div><p class="t">Krisp AI</p><p class="d">A modern UI system for noise-cancelling desktop software.</p></a>
-      <a class="slide cs" href="/work/zalando-stories"><div class="csm"><img src="/images/portfolio/gf-fennel.png" alt="Zalando Stories" loading="lazy"/></div><p class="t">Zalando Stories</p><p class="d">7M+ reach proved the bet. One motion system scaled it to 500+ stories.</p></a>
     </div></div>
   </section>
 


### PR DESCRIPTION
## Summary

- Update the About page's "Selected companies" list: add Layer, Direct TV, Territory Foods, VNYLST; remove Mezo
- Implements #65: remove Zalando Stories from the site entirely — the work-grid tile, the full project-detail entry, and the home canvas card
  - Fixes a knock-on TypeScript break: Zalando was the only project with real `motionDemos` entries, so removing it collapsed that field's inferred type to `never[]` everywhere else; fixed with an explicit element type on the now-empty arrays rather than widening the shared object shape (which would've broken the `'screenCarousel' in project` narrowing `ProjectPage.tsx` relies on for other optional fields)

## Test plan

- [x] `npm run build` passes clean
- [x] Verified `/about` renders all 13 companies with the correct count
- [x] Verified `/work` and the home carousel both show 8/7 entries respectively with Zalando gone
- [x] Verified `/work/zalando-stories` falls through to the existing not-found redirect to `/work`
- [x] Confirmed the home carousel's drag/snap logic computes bounds from `track.scrollWidth` at runtime, so no JS change was needed for the card-count drop


---
_Generated by [Claude Code](https://claude.ai/code/session_01BMEUxLAyt73gZPyp4LWUWg)_