### PR TITLE
Ship #64: replace every real image on mix1 pages with labeled placeholders

### DIFF
--- a/public/images/placeholder-mix1/ratio-1024x1024.svg
+++ b/public/images/placeholder-mix1/ratio-1024x1024.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="51" fill="#f9f8f5" letter-spacing="2">1:1</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="30" fill="rgba(249,248,245,0.55)" letter-spacing="2">1024x1024</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-1320x2868.svg
+++ b/public/images/placeholder-mix1/ratio-1320x2868.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="660" height="1434" viewBox="0 0 660 1434">
+  <rect width="660" height="1434" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="33" fill="#f9f8f5" letter-spacing="2">1320:2868</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="19" fill="rgba(249,248,245,0.55)" letter-spacing="2">660x1434</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-1600x1000.svg
+++ b/public/images/placeholder-mix1/ratio-1600x1000.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1000" viewBox="0 0 1600 1000">
+  <rect width="1600" height="1000" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#f9f8f5" letter-spacing="2">16:10</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">1600x1000</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-1600x900.svg
+++ b/public/images/placeholder-mix1/ratio-1600x900.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#f9f8f5" letter-spacing="2">16:9</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">1600x900</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-1603x2400.svg
+++ b/public/images/placeholder-mix1/ratio-1603x2400.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="802" height="1200" viewBox="0 0 802 1200">
+  <rect width="802" height="1200" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="40" fill="#f9f8f5" letter-spacing="2">1603:2400</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">802x1200</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-214x290.svg
+++ b/public/images/placeholder-mix1/ratio-214x290.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="856" height="1160" viewBox="0 0 856 1160">
+  <rect width="856" height="1160" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="42" fill="#f9f8f5" letter-spacing="2">214:290</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="25" fill="rgba(249,248,245,0.55)" letter-spacing="2">856x1160</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-451x567.svg
+++ b/public/images/placeholder-mix1/ratio-451x567.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="902" height="1134" viewBox="0 0 902 1134">
+  <rect width="902" height="1134" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#f9f8f5" letter-spacing="2">451:567</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(249,248,245,0.55)" letter-spacing="2">902x1134</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-686x868.svg
+++ b/public/images/placeholder-mix1/ratio-686x868.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="686" height="868" viewBox="0 0 686 868">
+  <rect width="686" height="868" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="34" fill="#f9f8f5" letter-spacing="2">686:868</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="20" fill="rgba(249,248,245,0.55)" letter-spacing="2">686x868</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-800x1000.svg
+++ b/public/images/placeholder-mix1/ratio-800x1000.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="1000" viewBox="0 0 800 1000">
+  <rect width="800" height="1000" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#f9f8f5" letter-spacing="2">4:5</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">800x1000</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-900x1600.svg
+++ b/public/images/placeholder-mix1/ratio-900x1600.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="1600" viewBox="0 0 900 1600">
+  <rect width="900" height="1600" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="45" fill="#f9f8f5" letter-spacing="2">9:16</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="26" fill="rgba(249,248,245,0.55)" letter-spacing="2">900x1600</text>
+</svg>

--- a/public/images/placeholder-mix1/ratio-99x124.svg
+++ b/public/images/placeholder-mix1/ratio-99x124.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="792" height="992" viewBox="0 0 792 992">
+  <rect width="792" height="992" fill="#090909"/>
+  <text x="50%" y="48%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="39" fill="#f9f8f5" letter-spacing="2">99:124</text>
+  <text x="50%" y="56%" text-anchor="middle" dominant-baseline="middle" font-family="ui-monospace, 'IBM Plex Mono', monospace" font-size="23" fill="rgba(249,248,245,0.55)" letter-spacing="2">792x992</text>
+</svg>

--- a/src/content/project.ts
+++ b/src/content/project.ts
@@ -6,7 +6,7 @@ export const project = {
     titleA: 'The BitcoinFi',
     titleB: 'Suite.',
     sub: 'Four product surfaces, one thesis: prove the circular Bitcoin economy works — borrow, swap, earn, and spend without selling your BTC.',
-    image: '/images/portfolio/project-hero-coinbase.png',
+    image: '/images/placeholder-mix1/ratio-1600x900.svg',
   },
   brief: {
     kicker: 'The brief',
@@ -23,14 +23,14 @@ export const project = {
   stillOne: {
     caption: 'MUSD-01 · Borrow securely, spend confidently',
     index: '01',
-    image: '/images/portfolio/project-01-borrow.png',
+    image: '/images/placeholder-mix1/ratio-1600x1000.svg',
   },
   twoUp: {
     caption: 'MUSD-02 / WALLET-03 · Loan status & portfolio',
     index: '02 — 03',
     images: [
-      { src: '/images/portfolio/project-02-loan.png', alt: 'Active loan status — LTV, MUSD balance, liquidation buffer' },
-      { src: '/images/portfolio/project-03-wallet.png', alt: 'Wallet overview — BTC, MUSD, and vault positions' },
+      { src: '/images/placeholder-mix1/ratio-800x1000.svg', alt: 'Active loan status — LTV, MUSD balance, liquidation buffer' },
+      { src: '/images/placeholder-mix1/ratio-800x1000.svg', alt: 'Wallet overview — BTC, MUSD, and vault positions' },
     ],
   },
   beforeAfter: {
@@ -38,27 +38,27 @@ export const project = {
     title: 'From flow to shipped product',
     beforeLabel: 'Early flow',
     afterLabel: 'Shipped product',
-    beforeImage: '/images/portfolio/mock-early-flow.png',
-    afterImage: '/images/portfolio/project-after-coinbase.png',
+    beforeImage: '/images/placeholder-mix1/ratio-1600x900.svg',
+    afterImage: '/images/placeholder-mix1/ratio-1600x900.svg',
   },
   stillTwo: {
     caption: 'EXPLORE-04 · Marketplace & earn, at scale',
     index: '04',
-    image: '/images/portfolio/project-04-marketplace.png',
+    image: '/images/placeholder-mix1/ratio-1600x1000.svg',
   },
   sheet: {
     kicker: 'The flow sheet',
     title: 'Eight surfaces.',
     hint: 'CLICK TO ENLARGE',
     frames: [
-      { frame: 'BORROW', image: '/images/portfolio/project-01-borrow.png' },
-      { frame: 'LOAN', image: '/images/portfolio/project-02-loan.png' },
-      { frame: 'WALLET', image: '/images/portfolio/project-03-wallet.png' },
-      { frame: 'EARN', image: '/images/portfolio/project-04-marketplace.png' },
-      { frame: 'HERO', image: '/images/portfolio/project-hero-coinbase.png' },
-      { frame: 'SHIPPED', image: '/images/portfolio/project-after-coinbase.png' },
-      { frame: 'EARLY', image: '/images/portfolio/mock-early-flow.png' },
-      { frame: 'BLOCKFI', image: '/images/portfolio/gf-blockfi.jpg' },
+      { frame: 'BORROW', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'LOAN', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'WALLET', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'EARN', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'HERO', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'SHIPPED', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'EARLY', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
+      { frame: 'BLOCKFI', image: '/images/placeholder-mix1/ratio-1024x1024.svg' },
     ],
   },
   quote: {
@@ -67,6 +67,6 @@ export const project = {
   next: {
     kicker: 'Next case',
     title: 'BlockFi — Bitcoin Rewards Card',
-    image: '/images/portfolio/gf-blockfi.jpg',
+    image: '/images/placeholder-mix1/ratio-1600x900.svg',
   },
 } as const;

--- a/src/mix1/content.ts
+++ b/src/mix1/content.ts
@@ -43,7 +43,7 @@ export const mix1Work = {
       name: 'Mezo Clay Design System',
       headline: 'Converting design debt into product infrastructure',
       desc: 'Led Mezo design system migration across three product phases (legacy, testnet, mainnet); post-launch audit established 70% component integration and identified systemic overrides from premature styling as the primary implementation bottleneck, informing governance decisions. Managed a direct report and an engineering contributor from execution through deployment. Partnered with the contributing designer to set quality standards and pattern library conventions, building out Uber Base into a React, WCAG 2.2-compliant library purpose-built for the Thesis BitcoinFi suite. Managed, built, and tested 2,000+ variants across 50+ base components, establishing the single source of truth every product surface shipped: the infrastructure behind $322M in testnet deposits, 154K transactions, and $151M TVL at mainnet, peaking at $200M+.',
-      image: '/images/portfolio/mock-thesis-systems.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'systems',
       sector: 'crypto',
     },
@@ -51,7 +51,7 @@ export const mix1Work = {
       name: 'Deposit on Mezo',
       headline: 'Improving the deposit flow that unlocked Mezo’s liquidity',
       desc: 'Depositing Bitcoin to Mezo wasn’t a standard transfer — users were bridging assets across chains into a protocol where a wrong address meant permanent loss of funds. Research confirmed the existing deposit flow was fundamentally broken — perceived as risky and confusing. The redesign introduced upfront deposit instructions, surfaced network context and minimum thresholds before commitment, and provided unambiguous success states so users knew their funds had arrived safely. The deposit flow became the primary on-ramp enabling liquidity for vaults, pools, and rewards — contributing to Mezo’s growth to $200M+ TVL.',
-      image: '/images/portfolio/project-hero-coinbase.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'product',
       sector: 'crypto',
     },
@@ -59,7 +59,7 @@ export const mix1Work = {
       name: 'Borrow MUSD on Mezo',
       headline: 'Making high-stakes borrowing feel safe, not complex',
       desc: 'MUSD borrowing required users to understand collateralization, liquidation risk, and variable APR simultaneously — concepts that had no mainstream equivalent. The design challenge wasn’t simplification for its own sake; it was making consequential financial decisions feel appropriately weighted without overwhelming users into inaction. The redesign introduced progressive disclosure, consolidated error handling to a single inline signal, and leaned on benchmarked design patterns to reduce DeFi complexity for a larger addressable market.',
-      image: '/images/portfolio/project-01-borrow.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'product',
       sector: 'crypto',
     },
@@ -67,7 +67,7 @@ export const mix1Work = {
       name: 'BlockFi Mobile',
       headline: 'Redefining mobile trading to drive 200%+ transaction volume in 90 days',
       desc: 'BlockFi’s mobile trading experience was scoped too narrowly — USD denomination was the surface problem, but the deeper opportunity was rebuilding the entire flow around how users actually trade. As Director, I pushed back on the original brief using product benchmarking and heuristic evaluation, moving buy/sell intent before the amount screen to eliminate a segmented control that was adding cognitive load, making room for surfacing recurring trades earlier in the flow — previously buried at the summary screen. Both decisions were validated through user testing before implementation, and applied consistently across web and mobile. Trades grew 200%+ within 90 days of launch — outpacing web-based trades for the first time — and contributed directly to BlockFi’s growth in service of 225K+ clients.',
-      image: '/images/portfolio/gf-blockfi.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'leadership',
       sector: 'fintech',
     },
@@ -75,7 +75,7 @@ export const mix1Work = {
       name: 'BlockFi — Credit Card Rewards (Mobile)',
       headline: 'Scoping and shipping the mobile experience behind the world’s first Bitcoin rewards credit card',
       desc: 'Performed as lead product designer for the world’s first Bitcoin rewards credit card — building the design system and implementing the native experience against a web version, reusing the same components across both to stave off design debt and create a unified cross-platform experience. Reached 50,000+ active cardholders within 90 days of national launch, spending 450% above the card industry average and pacing toward $2B+ in annualized volume (BlockFi, Oct 2021).',
-      image: '/images/portfolio/gf-blockfi.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'leadership',
       sector: 'fintech',
     },
@@ -83,7 +83,7 @@ export const mix1Work = {
       name: 'C@SH Native App',
       headline: 'Zero-to-one product design that informed a strategic pivot',
       desc: 'At an a16z Crypto portfolio company, I established the design function from zero — customizing Uber Base into a branded component library before a single internal designer was hired, doubling engineering speed and giving the team infrastructure to build with from day one. The VC principal set a high bar: a premium product resonating with an urban audience. We met it — validated through affinity testing — delivering a full light and dark mode experience. The same research surfaced a harder finding: the market hadn’t matured enough for a social wallet. That insight informed a strategic pivot, preserving capital that would otherwise have been burned against a product without sufficient traction.',
-      image: '/images/portfolio/gf-cash.png',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'leadership',
       sector: 'crypto',
     },
@@ -91,7 +91,7 @@ export const mix1Work = {
       name: 'EASI Food Delivery',
       headline: 'Rearchitecting EASI to win a second audience — and a $500M valuation',
       desc: 'EASI had a strong market position in Australian diaspora communities, but poor usability, frequent crashes, and a sub-3.0 App Store rating were capping their TAM. In six weeks, I used benchmarking to build stakeholder confidence for a full redesign, then rebuilt core ordering flow in parallel with engineering’s re-architecture — prototyping and testing each decision before handoff. App Store rating climbed from below 3.0 to 4.5 stars. EASI surpassed 1M+ users, reached a $500M+ valuation, and was acquired by HungryPanda in 2022 — whose acquisition rationale mirrored the market strategy the redesign was built around.',
-      image: '/images/portfolio/gf-easi.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'consultant',
       sector: 'consumer',
     },
@@ -99,7 +99,7 @@ export const mix1Work = {
       name: 'Krisp AI',
       headline: 'Product innovation for Krisp.ai’s noise cancelling desktop application',
       desc: 'Krisp had built strong utility as a consumer noise-cancellation tool, but the desktop experience hadn’t kept pace with what AI-native software was starting to look like. Engaged as principal design consultant, I redesigned the application around a modern UI system — introducing branded components to accelerate implementation, reduce design debt, and establish a visual foundation capable of scaling with the product. The engagement paused when COVID-19 created market uncertainty across the space. Krisp would later pivot into meeting intelligence and recording — a shift toward enterprise aesthetics and a design brief the original work wasn’t built to serve.',
-      image: '/images/portfolio/gf-krisp.jpg',
+      image: '/images/placeholder-mix1/ratio-451x567.svg',
       service: 'consultant',
       sector: 'ai',
     },
@@ -113,8 +113,8 @@ export const mix1About = {
   teamIntro: 'Osandi Sekoú Robinson — product & design leader.',
   teamBody:
     'I am product fanatic, music producer, entrepreneur, leader and perpetual student. My passion is in generating disruptive product/service ideas with extraordinary uses of technology while delivering products that find a place in the hearts of those who use them.',
-  portrait: '/images/osandi-portrait-anime.png',
-  capabilitiesFigure: '/images/portfolio/mock-poised.png',
+  portrait: '/images/placeholder-mix1/ratio-1024x1024.svg',
+  capabilitiesFigure: '/images/placeholder-mix1/ratio-214x290.svg',
   team: [{ name: 'Osandi Sekoú Robinson', role: 'Product & design leader' }],
   capabilities: [
     {
@@ -187,7 +187,7 @@ export const mix1About = {
     {
       name: 'Discover',
       copy: 'Discovery determines whether a team is solving the right problem before anyone commits to a solution. Widen the aperture before narrowing toward anything buildable. The output is alignment on the problem, the evidence needed, and why it matters to the business.',
-      image: '/images/studio/agency-01-9b4387d5aa.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: [
         'Customer feedback',
         'Quant data analysis',
@@ -204,13 +204,13 @@ export const mix1About = {
     {
       name: 'Explore',
       copy: 'With the evidential problem in sight, artifacts and written context align stakeholders — connecting hypotheses and objectives to human needs and business goals.',
-      image: '/images/studio/agency-05-6ff4e85875.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: ['Diagram', 'Journey map', 'Wireframe', 'Prompt design & prototyping'],
     },
     {
       name: 'Validate',
       copy: 'Validation can occur at multiple touchpoints with an array of artifacts, ensuring the work addresses the needs of users — and, inevitably, the business.',
-      image: '/images/studio/agency-06-c2c1790069.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: [
         'Card sorting',
         'Design reviews',
@@ -227,7 +227,7 @@ export const mix1About = {
     {
       name: 'Implement',
       copy: 'Collaborate closely with engineers for design alignment and capture details pre-release. For new components, ensure awareness for product consistency. Cross-functional stakeholders are informed via Loom and case-study briefs before final sign-off — including how we measure design intent.',
-      image: '/images/studio/agency-07-a0986e9d3f.webp',
+      image: '/images/placeholder-mix1/ratio-1603x2400.svg',
       methods: [
         'Feasibility sign-off',
         'Compliance sign-off',
@@ -369,7 +369,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Systems',
     readTime: 4,
-    image: '/images/portfolio/mock-thesis-systems.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Converting design debt into product infrastructure',
     intro:
       'What starts as a styling override always becomes a system problem. At Mezo, three product phases — legacy, testnet, mainnet — had accumulated enough inconsistency to slow every team touching the product. The work was infrastructure first, interface second.',
@@ -381,7 +381,7 @@ export const mix1Projects = [
           "Led the full migration to Mezo Clay — partnering with Uber Base as the foundation and building a WCAG 2.2-compliant React library purpose-built for the Thesis BitcoinFi suite. Managed a direct report and an engineering contributor from execution through deployment.",
           "The post-launch audit identified premature styling as the primary implementation bottleneck — a pattern that shows up in every fast-moving crypto team. The fix wasn't more components; it was clearer rules about when to override them.",
         ],
-        images: ['/images/portfolio/mock-thesis-systems.png', '/images/portfolio/mezo-hero.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: '2,000+ variants. 50+ base components. One source of truth.',
@@ -390,7 +390,7 @@ export const mix1Projects = [
           "Partnered with the contributing designer to set quality standards and pattern library conventions. Built and tested every variant against the Mezo product surfaces — deposit, borrow, wallet, explore — so each could ship without a separate design review cycle.",
           "The system became the infrastructure behind $322M in testnet deposits, 154K transactions, and $151M TVL at mainnet, peaking at $200M+.",
         ],
-        images: ['/images/portfolio/mezo-wallet.png', '/images/portfolio/mezo-explore.png', '/images/portfolio/mezo-borrow.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Design debt compounds silently until it stops shipping features.',
@@ -399,14 +399,10 @@ export const mix1Projects = [
           "A 70% component integration rate at post-launch audit sounds like success. It is — but the 30% that wasn't integrated told the real story: premature styling decisions made during testnet were being maintained as one-off overrides instead of being resolved back into the system.",
           "The governance decisions informed by that audit — when to override, when to extend, when to propose a new component — were as important as the components themselves.",
         ],
-        images: ['/images/portfolio/mock-thesis-systems.png', '/images/portfolio/mezo-borrow.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: [
-      '/images/portfolio/mock-thesis-systems.png',
-      '/images/portfolio/mezo-hero.png',
-      '/images/portfolio/mezo-wallet.png',
-    ],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'Infrastructure that outlasts the sprint cycle is the difference between a design system and a component dump.',
     stats: [
       { name: 'Component integration', description: 'Post-launch audit established the baseline for system governance decisions.', value: '70%' },
@@ -439,7 +435,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Product',
     readTime: 3,
-    image: '/images/portfolio/project-hero-coinbase.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: "Improving the deposit flow that unlocked Mezo's liquidity",
     intro:
       "Depositing Bitcoin to Mezo wasn't a standard transfer. Users were bridging assets across chains into a protocol where a wrong address meant permanent loss of funds. The bar for clarity wasn't high — it was non-negotiable.",
@@ -451,7 +447,7 @@ export const mix1Projects = [
           "The existing deposit flow was perceived as risky and confusing — no upfront context, no network guidance, no unambiguous success state. Users had to infer what was happening at every step.",
           "The redesign introduced upfront deposit instructions before any commitment, surfaced network context and minimum thresholds early, and delivered success states specific enough that users knew their funds had arrived safely — not just that a transaction had fired.",
         ],
-        images: ['/images/portfolio/project-hero-coinbase.png', '/images/portfolio/project-after-coinbase.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'The deposit flow became the primary on-ramp for all of Mezo\'s liquidity.',
@@ -460,10 +456,10 @@ export const mix1Projects = [
           "Vaults, pools, and rewards all depended on a working deposit experience. The redesign unblocked each of them — contributing directly to Mezo's growth to $200M+ TVL.",
           "Sprint completion held at 98% across the engagement, which meant the research and design process ran fast enough to stay ahead of engineering.",
         ],
-        images: ['/images/portfolio/mezo-hero.png', '/images/portfolio/mezo-explore.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/project-hero-coinbase.png', '/images/portfolio/project-after-coinbase.png', '/images/portfolio/mezo-hero.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'Clarity at the point of commitment is not a UX nicety in a protocol where a wrong address means permanent loss.',
     stats: [
       { name: 'TVL at mainnet', description: 'Deposit flow was the primary on-ramp for all Mezo liquidity growth.', value: '$200M+' },
@@ -494,7 +490,7 @@ export const mix1Projects = [
     year: '2023',
     service: 'Product',
     readTime: 3,
-    image: '/images/portfolio/project-01-borrow.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Making high-stakes borrowing feel safe, not complex',
     intro:
       'MUSD borrowing required users to hold collateralization ratio, liquidation threshold, and variable APR in their heads simultaneously. None of those concepts have mainstream equivalents. The design problem was weight, not simplification.',
@@ -506,7 +502,7 @@ export const mix1Projects = [
           "Progressive disclosure let us surface complexity only when it was relevant to the decision at hand. A user setting their collateral ratio doesn't need to see APR mechanics at the same moment.",
           "Error handling was consolidated to a single inline signal. Before the redesign, errors appeared in multiple places with inconsistent framing — adding cognitive load at the worst possible moment.",
         ],
-        images: ['/images/portfolio/project-01-borrow.png', '/images/portfolio/project-02-loan.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Benchmarking against established DeFi patterns reduced the learning curve.',
@@ -515,10 +511,10 @@ export const mix1Projects = [
           "The redesign borrowed interaction models from familiar financial interfaces — not to hide the complexity of DeFi, but to lower the entry cost for users coming from traditional finance.",
           "The borrow flow shipped as part of the mainnet launch suite, contributing to Mezo's $200M+ TVL and supporting expansion into a broader addressable market beyond early adopters.",
         ],
-        images: ['/images/portfolio/project-03-wallet.png', '/images/portfolio/project-04-marketplace.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/project-01-borrow.png', '/images/portfolio/project-02-loan.png', '/images/portfolio/project-03-wallet.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'The job isn\'t to make DeFi simple. It\'s to make consequential decisions feel proportionally weighted.',
     stats: [
       { name: 'TVL at mainnet', description: 'Borrow flow contributed to Mezo\'s liquidity growth alongside deposit and wallet.', value: '$200M+' },
@@ -548,7 +544,7 @@ export const mix1Projects = [
     year: '2021',
     service: 'Leadership',
     readTime: 4,
-    image: '/images/portfolio/gf-blockfi.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Redefining mobile trading to drive 200%+ transaction volume in 90 days',
     intro:
       "BlockFi's mobile trading had a surface problem and a structural one. USD denomination was the thing people complained about. The real issue was a flow built around what engineering found easiest to implement, not how traders actually think.",
@@ -560,7 +556,7 @@ export const mix1Projects = [
           "Product benchmarking and heuristic evaluation surfaced a pattern no one had named yet: the segmented control forcing users to choose denomination before intent was the single biggest source of drop-off. Moving buy/sell intent before the amount screen eliminated it.",
           "Recurring trades had been buried at the summary screen — three steps too late. Surfacing them earlier required a structural change to the flow that the original brief hadn't scoped. Both decisions were validated through user testing before implementation.",
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/mock-bbu.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Trades grew 200%+ in 90 days. Mobile outpaced web for the first time.',
@@ -569,10 +565,10 @@ export const mix1Projects = [
           "The same changes were applied consistently across web and mobile — not as a one-off mobile fix but as a rethought trading interaction model. The consistency mattered as much as the individual improvements.",
           "The result contributed directly to BlockFi's growth in service of 225K+ clients and $50M monthly revenue — and validated the case for design having a seat at product strategy decisions, not just execution.",
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/gf-fennel.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-blockfi.jpg', '/images/portfolio/mock-bbu.png', '/images/portfolio/gf-fennel.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'The brief was too small. Pushing back on it was the design work.',
     stats: [
       { name: 'Trades in 90 days', description: 'Mobile outpaced web-based trades for the first time following launch.', value: '+200%' },
@@ -608,11 +604,11 @@ export const mix1Projects = [
     year: '2021',
     service: 'Leadership',
     readTime: 4,
-    image: '/images/portfolio/gf-blockfi.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     // Placeholder frames, framed at the iPhone 17 Pro Max's screen ratio (1320x2868)
     // pending real card screens — swap each src once sourced (see TODO above). Rendered
     // as a body carousel (see ProjectPage.tsx), not in the hero.
-    screenCarousel: Array.from({ length: 12 }, () => '/images/portfolio/gf-blockfi.jpg'),
+    screenCarousel: Array.from({ length: 12 }, () => '/images/placeholder-mix1/ratio-1320x2868.svg'),
     headline: 'Scoping and shipping the mobile experience behind the world’s first Bitcoin rewards credit card',
     intro:
       "BlockFi's Bitcoin Rewards Visa card wasn't a marketing bet — it was a product bet on a category no issuer had shipped: a credit card that paid rewards in Bitcoin instead of points or cashback. Before launch it had already pulled a waitlist of roughly 400,000 signups (Dec 2020–Jul 2021), which meant the mobile experience — enrollment, card management, and rewards tracking — had to hold up under real demand from day one, not iterate its way there.",
@@ -624,7 +620,7 @@ export const mix1Projects = [
           'Lead designer, mobile, for the BlockFi Rewards Card experience. The card launched nationally in mid-2021 on the Visa network, issued by Evolve Bank & Trust and powered by Deserve’s card platform, converting a ~400K-signup waitlist into an active cardholder base.',
           'Built the design system and implemented the native experience against a web version — the same components reused across both platforms rather than diverging.',
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: '50,000+ active cardholders within 90 days of national launch, spending 450% above the card industry average and pacing toward $2B+ in annualized volume.',
@@ -633,10 +629,10 @@ export const mix1Projects = [
           'By December 2021, cardholders had grown past 70,000 — a secondary source (Shorty Awards), cited with lighter confidence than BlockFi’s own release above. Rewards distribution reached 120+ BTC (~$6.8M) as of October 12, 2021 (BlockFi, GlobeNewswire).',
           'That reuse staved off design debt and created a unified cross-platform experience — one system driving both native and web, not two drifting apart.',
         ],
-        images: ['/images/portfolio/gf-blockfi.jpg'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-blockfi.jpg'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead:
       '“Crypto rewards programs are a compelling way to engage consumers in the crypto economy. We’re excited to see programs like the BlockFi Rewards Visa Card, which offer rewards that are relevant to the growing community of digital currency adopters.” — Forbes, Jul 6 2021',
     stats: [
@@ -671,7 +667,7 @@ export const mix1Projects = [
     year: '2022',
     service: 'Leadership',
     readTime: 3,
-    image: '/images/portfolio/gf-cash.png',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Zero-to-one product design that informed a strategic pivot',
     intro:
       "Building a design function before the first hire means every decision compounds. The component library you build becomes the product. The research you run becomes the strategy.",
@@ -683,7 +679,7 @@ export const mix1Projects = [
           "Customized Uber Base into a branded library that doubled engineering speed and gave the team a shared vocabulary to build with from day one. The VC principal set a high bar — a premium product resonating with an urban audience — and we met it, validated through affinity testing.",
           "Full light and dark mode shipped. The same research surfaced a harder finding: the market hadn't matured enough for a social wallet.",
         ],
-        images: ['/images/portfolio/gf-cash.png', '/images/portfolio/mock-vinyl-crate.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: "The research that shaped the pivot preserved capital that would otherwise have been spent.",
@@ -692,10 +688,10 @@ export const mix1Projects = [
           "Identifying insufficient market traction before over-investing in the product direction was the most valuable output of the engagement. The design foundation remained intact for the company's next direction.",
           "Building 0→1 means the research has to do double duty — validating the product and validating the strategy. Here, it did both.",
         ],
-        images: ['/images/portfolio/mock-a16z.png', '/images/portfolio/gf-cash.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-cash.png', '/images/portfolio/mock-a16z.png', '/images/portfolio/mock-vinyl-crate.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'The most valuable deliverable was the research that stopped us from building the wrong thing.',
     stats: [
       { name: 'Design function', description: 'Built from zero before the first internal design hire.', value: '0 → 1' },
@@ -725,7 +721,7 @@ export const mix1Projects = [
     year: '2020',
     service: 'Consultant',
     readTime: 4,
-    image: '/images/portfolio/gf-easi.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: 'Rearchitecting EASI to win a second audience — and a $500M valuation',
     intro:
       "EASI had a real market and a broken product. A sub-3.0 App Store rating and frequent crashes weren't edge cases — they were capping the total addressable market. The problem wasn't the audience; it was the experience they were being asked to tolerate.",
@@ -737,7 +733,7 @@ export const mix1Projects = [
           "Six weeks. Skeptical stakeholders. A team that had shipped the original product and wasn't sure anything needed to change. Benchmarking gave us a shared language for what 'good' looked like — not opinions, but patterns from products the team already respected.",
           "Once the case was made, the redesign ran in parallel with engineering's re-architecture — prototyping and testing each decision before handoff, so no one was waiting on anyone.",
         ],
-        images: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/mock-ubiquiti.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'App Store rating: below 3.0 to 4.5. Acquired for $500M+.',
@@ -746,10 +742,10 @@ export const mix1Projects = [
           "EASI surpassed 1M+ users and reached a $500M+ valuation. HungryPanda's acquisition rationale in 2022 mirrored the market strategy the redesign was built around — expanding from diaspora communities into a broader urban audience.",
           "The six-week timeline wasn't a constraint. It was the discipline that kept the scope focused on what would move the numbers.",
         ],
-        images: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/gf-blinkist.jpg'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-easi.jpg', '/images/portfolio/gf-blinkist.jpg', '/images/portfolio/mock-ubiquiti.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'A 4.5-star rating is a market signal. The $500M acquisition validated the strategy the redesign was built around.',
     stats: [
       { name: 'App Store rating', description: 'Climbed from below 3.0 to 4.5 stars following the redesign launch.', value: '3.0→4.5' },
@@ -780,7 +776,7 @@ export const mix1Projects = [
     year: '2020',
     service: 'Consultant',
     readTime: 3,
-    image: '/images/portfolio/gf-krisp.jpg',
+    image: '/images/placeholder-mix1/ratio-99x124.svg',
     headline: "Product innovation for Krisp.ai's noise cancelling desktop application",
     intro:
       "Krisp had strong utility and a dated interface. The noise cancellation worked. The desktop experience hadn't kept pace with what AI-native software was starting to look like — and that gap was starting to matter.",
@@ -792,7 +788,7 @@ export const mix1Projects = [
           "Engaged as principal design consultant, I redesigned the application around a cohesive UI system — introducing branded components to accelerate implementation, reduce design debt, and establish a visual foundation capable of scaling with the product.",
           "The work ran until COVID-19 created market uncertainty across the consumer audio space. What was scoped as a foundation for growth became a foundation for a pivot.",
         ],
-        images: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-early-flow.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
       {
         lead: 'Krisp pivoted into meeting intelligence. The structural work held.',
@@ -801,10 +797,10 @@ export const mix1Projects = [
           "The shift toward enterprise aesthetics and recording features was a different design brief than the original work was built to serve. But the component layer and the system thinking behind it gave the team a structured starting point for that evolution.",
           "That's the value of system work over surface work — it outlives the original brief.",
         ],
-        images: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-apple-genius.png'],
+        images: ['/images/placeholder-mix1/ratio-686x868.svg', '/images/placeholder-mix1/ratio-686x868.svg'],
       },
     ],
-    mockups: ['/images/portfolio/gf-krisp.jpg', '/images/portfolio/mock-early-flow.png', '/images/portfolio/mock-apple-genius.png'],
+    mockups: ['/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg', '/images/placeholder-mix1/ratio-900x1600.svg'],
     closingLead: 'System work outlives the brief it was built for. That\'s the difference between components and infrastructure.',
     stats: [
       { name: 'Engagement type', description: 'Engaged as principal design consultant for the desktop UI system redesign.', value: 'Principal' },

--- a/src/mix1/markup/home.html
+++ b/src/mix1/markup/home.html
@@ -42,13 +42,13 @@
 
   <section class="caro" id="work">
     <div class="track-wrap" data-slider><div class="track">
-      <a class="slide cs" href="/work/mezo-clay"><div class="csm"><img src="/images/portfolio/mock-thesis-systems.png" alt="Mezo Clay Design System" loading="lazy"/></div><p class="t">Mezo Clay</p><p class="d">Converting design debt into product infrastructure — 2,000+ variants, $200M+ TVL.</p></a>
-      <a class="slide cs" href="/work/deposit-on-mezo"><div class="csm"><img src="/images/portfolio/project-hero-coinbase.png" alt="Deposit on Mezo" loading="lazy"/></div><p class="t">Deposit on Mezo</p><p class="d">The on-ramp that unlocked liquidity — trust, thresholds, and unambiguous success.</p></a>
-      <a class="slide cs" href="/work/borrow-musd"><div class="csm"><img src="/images/portfolio/project-01-borrow.png" alt="Borrow MUSD on Mezo" loading="lazy"/></div><p class="t">Borrow MUSD</p><p class="d">Making high-stakes borrowing feel safe, not complex.</p></a>
-      <a class="slide cs" href="/work/blockfi-mobile"><div class="csm"><img src="/images/portfolio/gf-blockfi.jpg" alt="BlockFi Mobile" loading="lazy"/></div><p class="t">BlockFi Mobile</p><p class="d">Redefining mobile trading — +200% volume in 90 days.</p></a>
-      <a class="slide cs" href="/work/cash-native-app"><div class="csm"><img src="/images/portfolio/gf-cash.png" alt="C@SH Native App" loading="lazy"/></div><p class="t">C@SH</p><p class="d">Zero-to-one at a16z Crypto that informed a strategic pivot.</p></a>
-      <a class="slide cs" href="/work/easi-food-delivery"><div class="csm"><img src="/images/portfolio/gf-easi.jpg" alt="EASI Food Delivery" loading="lazy"/></div><p class="t">EASI</p><p class="d">Rearchitecting to win a second audience — $500M valuation, acquired.</p></a>
-      <a class="slide cs" href="/work/krisp-ai"><div class="csm"><img src="/images/portfolio/gf-krisp.jpg" alt="Krisp AI" loading="lazy"/></div><p class="t">Krisp AI</p><p class="d">A modern UI system for noise-cancelling desktop software.</p></a>
+      <a class="slide cs" href="/work/mezo-clay"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="Mezo Clay Design System" loading="lazy"/></div><p class="t">Mezo Clay</p><p class="d">Converting design debt into product infrastructure — 2,000+ variants, $200M+ TVL.</p></a>
+      <a class="slide cs" href="/work/deposit-on-mezo"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="Deposit on Mezo" loading="lazy"/></div><p class="t">Deposit on Mezo</p><p class="d">The on-ramp that unlocked liquidity — trust, thresholds, and unambiguous success.</p></a>
+      <a class="slide cs" href="/work/borrow-musd"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="Borrow MUSD on Mezo" loading="lazy"/></div><p class="t">Borrow MUSD</p><p class="d">Making high-stakes borrowing feel safe, not complex.</p></a>
+      <a class="slide cs" href="/work/blockfi-mobile"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="BlockFi Mobile" loading="lazy"/></div><p class="t">BlockFi Mobile</p><p class="d">Redefining mobile trading — +200% volume in 90 days.</p></a>
+      <a class="slide cs" href="/work/cash-native-app"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="C@SH Native App" loading="lazy"/></div><p class="t">C@SH</p><p class="d">Zero-to-one at a16z Crypto that informed a strategic pivot.</p></a>
+      <a class="slide cs" href="/work/easi-food-delivery"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="EASI Food Delivery" loading="lazy"/></div><p class="t">EASI</p><p class="d">Rearchitecting to win a second audience — $500M valuation, acquired.</p></a>
+      <a class="slide cs" href="/work/krisp-ai"><div class="csm"><img src="/images/placeholder-mix1/ratio-1024x1024.svg" alt="Krisp AI" loading="lazy"/></div><p class="t">Krisp AI</p><p class="d">A modern UI system for noise-cancelling desktop software.</p></a>
     </div></div>
   </section>
 

--- a/src/mix1/pages/BuildPage.tsx
+++ b/src/mix1/pages/BuildPage.tsx
@@ -41,7 +41,7 @@ export function BuildPage() {
             Pixel button
           </a>
           <span className="mix1-pxbtn mix1-pxbtn--chip">[01]</span>
-          <img className="mix1-build__swatch" src="/images/portfolio/mock-poised.png" alt="" />
+          <img className="mix1-build__swatch" src="/images/placeholder-mix1/ratio-214x290.svg" alt="" />
         </div>
         <ul className="mix1-build__list">
           {mix1Build.keep.items.map((item) => (


### PR DESCRIPTION
## Summary

Closes #64. PR #63 implemented this but was left unmerged and went stale against the `/poised1` retirement in #68 — its poised1-only files (`SiteShell.tsx`, `FeaturedArchive.tsx`, `RollShowcase.tsx`, `WorkArchive.tsx`) no longer exist, so merging it directly would have reintroduced deleted code and broken the build. This PR ports the mix1-scoped image swap from #63 onto current `main` (applied cleanly via patch — 38 of its `content.ts` hunks applied as-is, only the already-removed Zalando hunks were skipped), then extends it to real gaps neither #63 nor the earlier Zalando-removal content sweep caught:

- `src/mix1/content.ts` — #63's image → placeholder-mix1 SVG mapping, applied
- `src/mix1/markup/home.html` — the raw home-canvas carousel embeds real `<img src>` directly in markup, entirely outside `content.ts`. #63 never touched this file; swapped all 6 real case-study screenshots
- `src/mix1/pages/BuildPage.tsx` — a decorative swatch image, also outside `content.ts` and outside #63's file list
- `src/content/project.ts` (the `/project` case-study page, ported from poised1 into mix1 in #68 — postdates #63 entirely) — swapped all 10 real image paths to new placeholder SVGs sized to this page's actual aspect ratios (16:9 hero/next, 16:10 stills, 4:5 two-up, 1:1 sheet frames), matching its `object-fit: cover` containers exactly so no layout shifted

New placeholders follow the existing `placeholder-mix1/` visual style (dark tile, ratio + pixel-dims label) rather than #63's separate `placeholder/` directory, whose SVGs are labeled "TEST ASSET · ISSUE #62" for an opt-in toggle — inappropriate to show unconditionally to real visitors on a live page.

## Test plan

- [x] `npm run build` passes clean
- [x] Headless-browser sweep confirmed zero non-placeholder `<img src>` across `/`, `/work`, `/about`, `/build`, `/work/:slug`, and `/project`
- [x] Screenshots confirm every grid, carousel, hero, and figure renders at its exact prior layout/size — no shift, since each placeholder matches its container's real aspect ratio


---
_Generated by [Claude Code](https://claude.ai/code/session_01BMEUxLAyt73gZPyp4LWUWg)_